### PR TITLE
Fix integration tests in CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <argLine>-Xmx4G</argLine>
+        <argLine>-Xmx128M</argLine>
         <skipITs>true</skipITs>
     </properties>
     <dependencies>
@@ -180,9 +180,10 @@
                 <version>2.12.4</version>
                 <configuration>
                     <!--forkedProcessTimeoutInSeconds>0</forkedProcessTimeoutInSeconds-->
-                    <argLine>-Xmx500M ${argLine}</argLine><!-- set heap memory for mvn junit tests -->
+                    <argLine>${argLine}</argLine><!-- set heap memory for mvn junit tests -->
                     <excludes>
                         <exclude>**/perf/*.java</exclude>
+                        <exclude>**/*Test.java</exclude>
                         <exclude>**/ConnectionSettingsTest.java</exclude> <!-- Sergey, this test needs to be fixed-->
                          <exclude>**/WatchdogChannelKillerTest.java</exclude> <!-- Sergey, this test needs to be fixed-->
                     </excludes>
@@ -193,7 +194,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.20.1</version>
                 <configuration>
-                    <argLine>-Xmx500M ${argLine}</argLine><!-- set heap memory for mvn junit tests -->
+                    <argLine>${argLine}</argLine><!-- set heap memory for mvn junit tests -->
                     <skipITs>${skipITs}</skipITs>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,6 @@
                     <argLine>${argLine}</argLine><!-- set heap memory for mvn junit tests -->
                     <excludes>
                         <exclude>**/perf/*.java</exclude>
-                        <exclude>**/*Test.java</exclude>
                         <exclude>**/ConnectionSettingsTest.java</exclude> <!-- Sergey, this test needs to be fixed-->
                          <exclude>**/WatchdogChannelKillerTest.java</exclude> <!-- Sergey, this test needs to be fixed-->
                     </excludes>

--- a/src/test/java/com/splunk/cloudfwd/test/integration/AbstractReconciliationTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/AbstractReconciliationTest.java
@@ -235,21 +235,25 @@ public abstract class AbstractReconciliationTest extends AbstractConnectionTest 
     }
     return EntityUtils.toString(httpResponse.getEntity(), "utf-8");
   }
-
-  protected void deleteTestToken() {
-    if (TOKEN_VALUE != null) {
+  protected void deleteTestToken(String tokenName) {
       try {
         HttpDelete httpRequest = new HttpDelete(mgmtSplunkUrl() +
-                "/services/data/inputs/http/" + TOKEN_NAME);
+                "/services/data/inputs/http/" + tokenName);
         HttpResponse httpResponse = httpClient.execute(httpRequest);
         parseHttpResponse(httpResponse);
         LOG.debug("deleteTestToken: httpResponse: " + httpResponse);
         LOG.info("deleteTestToken: Successfully deleted token: TOKEN_NAME=" +
-                TOKEN_NAME + " TOKEN_VALUE=" + TOKEN_VALUE);
-        TOKEN_VALUE = null;
+          tokenName);
       } catch (Exception ex) {
-        Assert.fail("deleteTestToken: failed with ex: " + ex.getMessage());
+        Assert.fail("deleteTestToken: Couldn't delete token_name=" + tokenName 
+          + ". Failed with ex: " + ex.getMessage());
       }
+  }
+
+  protected void deleteTestToken() {
+    if (TOKEN_VALUE != null) {
+      deleteTestToken(TOKEN_NAME);
+      TOKEN_VALUE = null;
     } else {
       LOG.warn("Skipped deleting test token since test didn't create a token.");
     }
@@ -335,7 +339,13 @@ public abstract class AbstractReconciliationTest extends AbstractConnectionTest 
 
   // pass sourcetype=null to use the token default sourcetype
   protected String createTestToken(String sourcetype, boolean useACK) {
-    if (TOKEN_VALUE != null) deleteTestToken();
+    String oldToken = null;
+    // delete the existing token AFTER the new one is created so Connection
+    // doesn't get stuck with an invalid token
+    if (TOKEN_VALUE != null) {
+      oldToken = TOKEN_NAME;
+    }
+    
     createTestIndex();
     TOKEN_NAME = java.util.UUID.randomUUID().toString();
     try {
@@ -375,6 +385,11 @@ public abstract class AbstractReconciliationTest extends AbstractConnectionTest 
       Assert.fail("createTestToken: Failed to create token, ex: " +
               ex.getMessage());
     }
+    
+    if (oldToken != null) {
+      deleteTestToken(oldToken);
+    }
+    
     return TOKEN_VALUE;
   }
 

--- a/src/test/java/com/splunk/cloudfwd/test/integration/AbstractReconciliationTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/AbstractReconciliationTest.java
@@ -89,10 +89,12 @@ public abstract class AbstractReconciliationTest extends AbstractConnectionTest 
   }
 
   @Before
-  public void init() {
+  public void setUp() {
     if (!HEC_ENABLED) {
       enableHec();
     }
+    LOG.info("Starting setUp");
+    super.setUp();
   }
 
   @After
@@ -291,6 +293,7 @@ public abstract class AbstractReconciliationTest extends AbstractConnectionTest 
   }
 
   protected void enableHec() {
+    LOG.info("Starting enableHec");
     try {
       HttpPost httpRequest = new HttpPost(mgmtSplunkUrl() +
               "/services/data/inputs/http/http");

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -24,7 +24,7 @@ limitations under the License.
     </Console>    
   </Appenders>
   <Loggers>
-    <Root level="info">
+    <Root level="error">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>


### PR DESCRIPTION

Enables Integration Tests in Docker builds, which will trigger them to run in Codeship CI.

* remove 4G limit overwriting local limits
* switch to error log level
* limit java test process memory, build docker from oracle java base image
* fix setUp method name to enableHec