### PR TITLE
Feature/call failed on close now

### DIFF
--- a/src/main/java/com/splunk/cloudfwd/error/HecConnectionStateException.java
+++ b/src/main/java/com/splunk/cloudfwd/error/HecConnectionStateException.java
@@ -79,7 +79,11 @@ public class HecConnectionStateException extends IllegalStateException {
         /**
          * No ConnectionCallbacks provided
          */
-        NO_CALLBACKS_PROVIDED        
+        NO_CALLBACKS_PROVIDED,
+        /**
+         * Connection was closed and with unacknowledged events still in flight.
+         */
+        CONNECTION_CLOSED
     }
     private final Type type;
 

--- a/src/main/java/com/splunk/cloudfwd/impl/util/CallbackInterceptor.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/CallbackInterceptor.java
@@ -49,7 +49,12 @@ public class CallbackInterceptor implements ConnectionCallbacks {
             LOG.error("Caught exception from ConnectionCallbacks.acknowledged: " + e.getMessage());
             LOG.error(e.getMessage(), e);
         } finally {
-            ((EventBatchImpl) events).cancelEventTrackers(); //remove the EventBatchImpl from the places in the system it should be removed
+            try {
+                ((EventBatchImpl) events).cancelEventTrackers(); //remove the EventBatchImpl from the places in the system it should be removed
+            } catch (Exception e) {
+                LOG.error("Caught exception in finally block of callback interceptor acknowledged: " + e.getMessage());
+                LOG.error(e.getMessage(), e);
+            }
         }
     }
 
@@ -65,10 +70,15 @@ public class CallbackInterceptor implements ConnectionCallbacks {
             LOG.error("Caught exception from ConnectionCallbacks.failed: " + e.getMessage());
             LOG.error(e.getMessage(), e);
         } finally {
-            if (null != events) {
-                ((EventBatchImpl)events).setFailed(true);
-                ((EventBatchImpl)events).cancelEventTrackers();//remove the EventBatchImpl from the places in the system it should be removed
-                this.cpManager.release((EventBatchImpl)events);
+            try {
+                if (null != events) {
+                    ((EventBatchImpl) events).setFailed(true);
+                    ((EventBatchImpl) events).cancelEventTrackers();//remove the EventBatchImpl from the places in the system it should be removed
+                    this.cpManager.release((EventBatchImpl) events);
+                }
+            } catch (Exception e) {
+                LOG.error("Caught exception in finally block of callback interceptor failed: " + e.getMessage());
+                LOG.error(e.getMessage(), e);
             }
         }
     }
@@ -89,12 +99,22 @@ public class CallbackInterceptor implements ConnectionCallbacks {
 
     @Override
     public void systemError(Exception e) {
-        callbacks.systemError(e);
+        try {
+            callbacks.systemError(e);
+        } catch (Exception ex) {
+            LOG.error("Caught exception from ConnectionCallbacks.systemError: " + ex.getMessage());
+            LOG.error(ex.getMessage(), ex);
+        }
     }
 
     @Override
     public void systemWarning(Exception e) {
-        callbacks.systemWarning(e);
+        try {
+            callbacks.systemWarning(e);
+        } catch (Exception ex) {
+            LOG.error("Caught exception from ConnectionCallbacks.systemWarning: " + ex.getMessage());
+            LOG.error(ex.getMessage(), ex);
+        }
     }
 
 }

--- a/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
@@ -18,6 +18,9 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
+ * Optionally pass command line parameters "token" and "url" as: 
+ * mvn test -Dtest=MultiThreadedVolumeTest -DargLine="-Durl=<URL> -Dtoken=<TOKEN>"
+ * 
  * Created by eprokop on 9/13/17.
  */
 public class MultiThreadedVolumeTest extends AbstractPerformanceTest {

--- a/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
@@ -101,6 +101,14 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
     @Override
     protected Properties getProps() {
         Properties p = new Properties();
+        String token = System.getProperty("token");
+        String url = System.getProperty("url");
+        if (System.getProperty("token") != null) {
+            p.put(PropertyKeys.TOKEN, token);
+        }
+        if (System.getProperty("url") != null) {
+            p.put(PropertyKeys.COLLECTOR_URI, url);
+        }
         p.put(PropertyKeys.MOCK_HTTP_KEY, "false");
         p.put(KEY_ENABLE_TEST_PROPERTIES, false);
         p.put(PropertyKeys.MOCK_HTTP_CLASSNAME, "com.splunk.cloudfwd.impl.sim.SimulatedHECEndpoints");


### PR DESCRIPTION
- call failed callback on any unacked events in Connection.closeNow()
- allow passing token and url as command line parameters to MultiThreadedVolumeTest