### PR TITLE
Connections refactor 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
             <type>jar</type>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-properties</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+        <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>

--- a/src/main/java/com/splunk/cloudfwd/ConnectionSettings.java
+++ b/src/main/java/com/splunk/cloudfwd/ConnectionSettings.java
@@ -156,8 +156,8 @@ public class ConnectionSettings {
     }
 
     public void setConnection(Connection c) {
-        connection = (ConnectionImpl)c;
-        LOG = connection.getLogger(ConnectionSettings.class.getName());
+        this.connection = (ConnectionImpl)c;
+        this.LOG = this.connection.getLogger(ConnectionSettings.class.getName());
     }
 
     /* ***************************** UTIL ******************************* */
@@ -175,11 +175,11 @@ public class ConnectionSettings {
 
 
     public List<URL> getUrls() {
-        return urlsStringToList(url);
+        return urlsStringToList(this.url);
     }
 
     public String getUrlString() {
-        return url;
+        return this.url;
     }
 
     protected List<URL> urlsStringToList(String urlsListAsString) {
@@ -228,51 +228,51 @@ public class ConnectionSettings {
     }
 
     public int getChannelsPerDestination() {
-        return applyDefaultIfNull(channelsPerDest, DEFAULT_CHANNELS_PER_DESTINATION);
+        return applyDefaultIfNull(this.channelsPerDest, DEFAULT_CHANNELS_PER_DESTINATION);
     }
 
     public long getUnresponsiveChannelDecomMS() {
-        return applyDefaultIfNull(unresponsiveChannelDecomMS, DEFAULT_UNRESPONSIVE_MS);
+        return applyDefaultIfNull(this.unresponsiveChannelDecomMS, DEFAULT_UNRESPONSIVE_MS);
     }
 
     public long getAckPollMS() {
-        return applyDefaultIfNull(ackPollMS, DEFAULT_ACK_POLL_MS);
+        return applyDefaultIfNull(this.ackPollMS, DEFAULT_ACK_POLL_MS);
     }
 
     public long getHealthPollMS() {
-        return applyDefaultIfNull(healthPollMS, DEFAULT_HEALTH_POLL_MS);
+        return applyDefaultIfNull(this.healthPollMS, DEFAULT_HEALTH_POLL_MS);
     }
 
     public int getMaxTotalChannels() {
-        return applyDefaultIfNull(maxTotalChannels, DEFAULT_MAX_TOTAL_CHANNELS);
+        return applyDefaultIfNull(this.maxTotalChannels, DEFAULT_MAX_TOTAL_CHANNELS);
     }
 
     public int getMaxUnackedEventBatchPerChannel() {
-        return applyDefaultIfNull(maxUnackedPerChannel, DEFAULT_MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL);
+        return applyDefaultIfNull(this.maxUnackedPerChannel, DEFAULT_MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL);
     }
 
     public int getEventBatchSize() {
-        return applyDefaultIfNull(eventBatchSize, DEFAULT_EVENT_BATCH_SIZE);
+        return applyDefaultIfNull(this.eventBatchSize, DEFAULT_EVENT_BATCH_SIZE);
     }
 
     public long getChannelDecomMS() {
-        return applyDefaultIfNull(channelDecomMS, DEFAULT_DECOM_MS);
+        return applyDefaultIfNull(this.channelDecomMS, DEFAULT_DECOM_MS);
     }
     
     public long getChannelQuiesceTimeoutMS() {
-        return applyDefaultIfNull(channelQuiesceTimeoutMS, DEFAULT_CHANNEL_QUIESCE_TIMEOUT_MS);
+        return applyDefaultIfNull(this.channelQuiesceTimeoutMS, DEFAULT_CHANNEL_QUIESCE_TIMEOUT_MS);
     }
 
     public long getAckTimeoutMS() {
-        return applyDefaultIfNull(ackTimeoutMS, DEFAULT_ACK_TIMEOUT_MS);
+        return applyDefaultIfNull(this.ackTimeoutMS, DEFAULT_ACK_TIMEOUT_MS);
     }
 
     public long getBlockingTimeoutMS() {
-        return applyDefaultIfNull(blockingTimeoutMS, DEFAULT_BLOCKING_TIMEOUT_MS);
+        return applyDefaultIfNull(this.blockingTimeoutMS, DEFAULT_BLOCKING_TIMEOUT_MS);
     }
     
     public String getMockHttpClassname() {
-        return applyDefaultIfNull(mockHttpClassname, "com.splunk.cloudfwd.impl.sim.SimulatedHECEndpoints");
+        return applyDefaultIfNull(this.mockHttpClassname, "com.splunk.cloudfwd.impl.sim.SimulatedHECEndpoints");
     }
 
     public Endpoints getSimulatedEndpoints() {
@@ -285,25 +285,25 @@ public class ConnectionSettings {
     }
 
     public long getPreFlightTimeoutMS() {
-        return applyDefaultIfNull(preFlightTimeoutMS, DEFAULT_PREFLIGHT_TIMEOUT_MS);
+        return applyDefaultIfNull(this.preFlightTimeoutMS, DEFAULT_PREFLIGHT_TIMEOUT_MS);
     }
 
     public boolean isCertValidationDisabled() {
-        return applyDefaultIfNull(disableCertificateValidation, false);
+        return applyDefaultIfNull(this.disableCertificateValidation, false);
     }
 
     public boolean isHttpDebugEnabled() {
-        return applyDefaultIfNull(enableHttpDebug, false);
+        return applyDefaultIfNull(this.enableHttpDebug, false);
     }
 
     public boolean isCheckpointEnabled() {
-        return applyDefaultIfNull(enableCheckpoints, DEFAULT_ENABLE_CHECKPOINTS);
+        return applyDefaultIfNull(this.enableCheckpoints, DEFAULT_ENABLE_CHECKPOINTS);
     }
 
     public String getSSLCertContent() {
-        String certKey = sslCertContent;
+        String certKey = this.sslCertContent;
         if (isCloudInstance()) {
-            certKey = cloudSslCertContent;
+            certKey = this.cloudSslCertContent;
         }
 
         if (certKey != null) {
@@ -313,16 +313,16 @@ public class ConnectionSettings {
     }
 
     public int getMaxRetries() {
-        return applyDefaultIfNull(maxRetries, DEFAULT_RETRIES);
+        return applyDefaultIfNull(this.maxRetries, DEFAULT_RETRIES);
     }
 
     public int getMaxPreflightRetries() {
-        return applyDefaultIfNull(maxPreflightTries, DEFAULT_PREFLIGHT_RETRIES);
+        return applyDefaultIfNull(this.maxPreflightTries, DEFAULT_PREFLIGHT_RETRIES);
     }
 
     public ConnectionImpl.HecEndpoint getHecEndpointType() {
         ConnectionImpl.HecEndpoint endpoint;
-        String type = applyDefaultIfNull(hecEndpointType, DEFAULT_HEC_ENDPOINT_TYPE);
+        String type = applyDefaultIfNull(this.hecEndpointType, DEFAULT_HEC_ENDPOINT_TYPE);
         if (type.equals("raw")) {
             endpoint = ConnectionImpl.HecEndpoint.RAW_EVENTS_ENDPOINT;
         } else if (type.equals("event")) {
@@ -336,37 +336,37 @@ public class ConnectionSettings {
     }
 
     public String getToken() {
-        if (splunkHecToken == null) {
+        if (this.splunkHecToken == null) {
             throw new HecConnectionStateException(
                     "HEC token missing from Connection configuration. " + "See PropertyKeys.TOKEN",
                     HecConnectionStateException.Type.CONFIGURATION_EXCEPTION);
         }
-        return splunkHecToken;
+        return this.splunkHecToken;
     }
 
     public boolean isMockHttp() {
-        return applyDefaultIfNull(mockHttp, false);
+        return applyDefaultIfNull(this.mockHttp, false);
     }
 
 
     public Boolean getTestPropertiesEnabled() {
-        return applyDefaultIfNull(testPropertiesEnabled, false);
+        return applyDefaultIfNull(this.testPropertiesEnabled, false);
     }
 
     public String getHost() {
-        return splunkHecHost;
+        return this.splunkHecHost;
     }
 
     public String getSource() {
-        return splunkHecSource;
+        return this.splunkHecSource;
     }
 
     public String getSourcetype() {
-        return splunkHecSourcetype;
+        return this.splunkHecSourcetype;
     }
 
     public String getIndex() {
-        return splunkHecIndex;
+        return this.splunkHecIndex;
     }
 
     /* ***************************** SETTERS ******************************* */
@@ -380,9 +380,9 @@ public class ConnectionSettings {
             int was = numChannels;
             numChannels = DEFAULT_CHANNELS_PER_DESTINATION;
             getLog().debug("{}, defaulting {} to {}", was, CHANNELS_PER_DESTINATION, numChannels);
-            channelsPerDest = DEFAULT_CHANNELS_PER_DESTINATION;
+            this.channelsPerDest = DEFAULT_CHANNELS_PER_DESTINATION;
         }
-        channelsPerDest = numChannels;
+        this.channelsPerDest = numChannels;
     }
 
     public void setUnresponsiveMS(long decomMS) {
@@ -390,9 +390,9 @@ public class ConnectionSettings {
             long was = decomMS;
             decomMS = DEFAULT_UNRESPONSIVE_MS;
             getLog().debug("{}, defaulting {} to {}", was, UNRESPONSIVE_MS, decomMS);
-            unresponsiveChannelDecomMS = DEFAULT_UNRESPONSIVE_MS;
+            this.unresponsiveChannelDecomMS = DEFAULT_UNRESPONSIVE_MS;
         }
-        unresponsiveChannelDecomMS = decomMS;
+        this.unresponsiveChannelDecomMS = decomMS;
     }
 
     public void setAckPollMS(long pollMS) {
@@ -401,7 +401,7 @@ public class ConnectionSettings {
             pollMS = MIN_ACK_POLL_MS;
             getLog().debug("{}, defaulting {} to smallest allowed value of {}", was, ACK_POLL_MS, pollMS);
         }
-        ackPollMS = pollMS;
+        this.ackPollMS = pollMS;
     }
 
     public void setHealthPollMS(long pollMS) {
@@ -410,7 +410,7 @@ public class ConnectionSettings {
             pollMS = MIN_HEALTH_POLL_MS;
             getLog().debug("{}, defaulting {} to smallest allowed value {}", was, HEALTH_POLL_MS, pollMS);
         }
-        healthPollMS = pollMS;
+        this.healthPollMS = pollMS;
     }
 
     public void setMaxTotalChannels(int totalChannels) {
@@ -419,7 +419,7 @@ public class ConnectionSettings {
             totalChannels = Integer.MAX_VALUE; //effectively no limit by default
             getLog().debug("{}, defaulting {} to no-limit {}", was, MAX_TOTAL_CHANNELS, totalChannels);
         }
-        maxTotalChannels = totalChannels;
+        this.maxTotalChannels = totalChannels;
     }
 
     public void setMaxUnackedEventBatchPerChannel(int batchesPerChannel) {
@@ -429,7 +429,7 @@ public class ConnectionSettings {
             batchesPerChannel = max;
             getLog().debug("{}, defaulting {} to no limit {}", was, MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL, batchesPerChannel);
         }
-        maxUnackedPerChannel = batchesPerChannel;
+        this.maxUnackedPerChannel = batchesPerChannel;
     }
 
     /**
@@ -441,7 +441,7 @@ public class ConnectionSettings {
             numChars = MIN_EVENT_BATCH_SIZE;
             getLog().debug("{}, defaulting {} to smallest allowed value {}", was, EVENT_BATCH_SIZE, numChars);
         }
-        eventBatchSize = numChars;
+        this.eventBatchSize = numChars;
     }
 
     public void setChannelDecomMS(long decomMS) {
@@ -454,16 +454,16 @@ public class ConnectionSettings {
                     "Ignoring setting for " + CHANNEL_DECOM_MS + " because it is less than minimum acceptable value: " + MIN_DECOM_MS);
             decomMS = MIN_DECOM_MS;
         }
-        channelDecomMS = decomMS;
+        this.channelDecomMS = decomMS;
     }
     
     public void setChannelQuiesceTimeoutMS(long timeoutMS) {
         if (timeoutMS < PropertyKeys.MIN_CHANNEL_QUIESCE_TIMEOUT_MS && !isMockHttp()) {
             LOG.warn(PropertyKeys.CHANNEL_QUIESCE_TIMEOUT_MS +
                     " was set to a potentially too-low value, reset to min value: " + timeoutMS);
-            channelQuiesceTimeoutMS = MIN_CHANNEL_QUIESCE_TIMEOUT_MS;
+            this.channelQuiesceTimeoutMS = MIN_CHANNEL_QUIESCE_TIMEOUT_MS;
         } else {
-            channelQuiesceTimeoutMS = timeoutMS;
+            this.channelQuiesceTimeoutMS = timeoutMS;
         }
     }
 
@@ -477,7 +477,7 @@ public class ConnectionSettings {
                 getLog().warn(ACK_TIMEOUT_MS + " was set to a potentially too-low value, reset to min value: " + timeoutMS);
                 timeoutMS = MIN_ACK_TIMEOUT_MS;
             }
-            ackTimeoutMS = timeoutMS;
+            this.ackTimeoutMS = timeoutMS;
             if (connection != null) {
                 connection.getTimeoutChecker().setTimeout();
             }
@@ -488,11 +488,11 @@ public class ConnectionSettings {
         if (timeoutMS < 0) {
             throw new IllegalArgumentException(BLOCKING_TIMEOUT_MS + " must be positive.");
         }
-        blockingTimeoutMS = timeoutMS;
+        this.blockingTimeoutMS = timeoutMS;
     }
 
     public void setMockHttpClassname(String endpoints) {
-        mockHttpClassname = endpoints;
+        this.mockHttpClassname = endpoints;
     }
     
     public void setPreFlightTimeoutMS(long timeoutMS) {
@@ -500,15 +500,15 @@ public class ConnectionSettings {
             throw new IllegalArgumentException(
                     PropertyKeys.PREFLIGHT_TIMEOUT_MS + " must be greater than zero.");
         }
-        preFlightTimeoutMS = timeoutMS;
+        this.preFlightTimeoutMS = timeoutMS;
     }
 
     public void disableCertValidation() {
-        disableCertificateValidation = true;
+        this.disableCertificateValidation = true;
     }
     
     public void enableCertValidation() {
-        disableCertificateValidation = false;
+        this.disableCertificateValidation = false;
     }
 
     public void setHttpDebugEnabled(Boolean mode) {
@@ -528,14 +528,14 @@ public class ConnectionSettings {
     }
 
     public void setCheckpointEnabled(Boolean mode) {
-        enableCheckpoints = mode;
+        this.enableCheckpoints = mode;
     }
 
     public void setSSLCertContent(String cert) {
         if (isCloudInstance()) {
-            cloudSslCertContent = cert;
+            this.cloudSslCertContent = cert;
         } else {
-            sslCertContent = cert;
+            this.sslCertContent = cert;
         }
     }
 
@@ -545,7 +545,7 @@ public class ConnectionSettings {
             retries = Integer.MAX_VALUE;
             getLog().debug("{}, defaulting {} to maximum allowed value {}", was, RETRIES, retries);
         }
-        maxRetries = retries;
+        this.maxRetries = retries;
     }
 
     public void setMaxPreflightRetries(int retries) {
@@ -554,7 +554,7 @@ public class ConnectionSettings {
             retries = Integer.MAX_VALUE;
             getLog().debug("{}, defaulting {} to maximum allowed value {}", was, PREFLIGHT_RETRIES, retries);
         }
-        maxPreflightTries = retries;
+        this.maxPreflightTries = retries;
     }
 
     public void setHecEndpointType(ConnectionImpl.HecEndpoint type) {
@@ -568,7 +568,7 @@ public class ConnectionSettings {
                     "Unrecognized HEC Endpoint type. Defaulting to " + DEFAULT_HEC_ENDPOINT_TYPE + ". See PropertyKeys.HEC_ENDPOINT_TYPE.");
             endpoint = DEFAULT_HEC_ENDPOINT_TYPE;
         }
-        hecEndpointType = endpoint;
+        this.hecEndpointType = endpoint;
     }
 
     /**
@@ -578,14 +578,14 @@ public class ConnectionSettings {
      * @param token
      */
     public void setToken(String token) {
-        if (!token.equals(getToken())) {
-            splunkHecToken = token;
+        if (!token.equals(this.splunkHecToken)) {
+            this.splunkHecToken = token;
             checkAndRefreshChannels();
         }
     }
 
     public void setMockHttp(Boolean mode) {
-        mockHttp = mode;
+        this.mockHttp = mode;
     }
 
   /**
@@ -595,15 +595,15 @@ public class ConnectionSettings {
    */
   public void setUrls(String urls) {
       if (connection != null && !urlsStringToList(urls).equals(getUrls())) {
-          url = urls;
+          this.url = urls;
           checkAndRefreshChannels();
       } else {
-          url = urls;
+          this.url = urls;
       }
   }
 
   public void setTestPropertiesEnabled(Boolean enabled) {
-      testPropertiesEnabled = enabled;
+      this.testPropertiesEnabled = enabled;
   }
   
     /**
@@ -612,7 +612,7 @@ public class ConnectionSettings {
      */
   public void setHost(String host) {
       if (!StringUtils.isEmpty(host) && !host.equals(getHost())) {
-          splunkHecHost = host;
+          this.splunkHecHost = host;
           checkAndRefreshChannels();
       }
   }
@@ -623,7 +623,7 @@ public class ConnectionSettings {
      */
   public void setIndex(String index) {
       if (!StringUtils.isEmpty(index) && !index.equals(getIndex())) {
-          splunkHecIndex = index;
+          this.splunkHecIndex = index;
           checkAndRefreshChannels();
       }
   }
@@ -634,7 +634,7 @@ public class ConnectionSettings {
      */
   public void setSource(String source) {
       if (!StringUtils.isEmpty(source) && !source.equals(getSource())) {
-          splunkHecSource = source;
+          this.splunkHecSource = source;
           checkAndRefreshChannels();
       }
   }
@@ -645,7 +645,7 @@ public class ConnectionSettings {
      */
   public void setSourcetype(String sourcetype) {
       if (!StringUtils.isEmpty(sourcetype) && !sourcetype.equals(getSourcetype())) {
-          splunkHecSourcetype = sourcetype;
+          this.splunkHecSourcetype = sourcetype;
           checkAndRefreshChannels(); 
       }
   }

--- a/src/main/java/com/splunk/cloudfwd/ConnectionSettings.java
+++ b/src/main/java/com/splunk/cloudfwd/ConnectionSettings.java
@@ -16,370 +16,170 @@
 package com.splunk.cloudfwd;
 
 import static com.splunk.cloudfwd.PropertyKeys.ACK_POLL_MS;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
-import com.splunk.cloudfwd.error.HecMissingPropertiesException;
-import com.splunk.cloudfwd.error.HecIllegalStateException;
-import static com.splunk.cloudfwd.PropertyKeys.ACK_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.CHANNELS_PER_DESTINATION;
-import static com.splunk.cloudfwd.PropertyKeys.DEFAULT_ACK_POLL_MS;
-import static com.splunk.cloudfwd.PropertyKeys.DEFAULT_CHANNELS_PER_DESTINATION;
-import static com.splunk.cloudfwd.PropertyKeys.DEFAULT_HEALTH_POLL_MS;
-import static com.splunk.cloudfwd.PropertyKeys.DEFAULT_MAX_TOTAL_CHANNELS;
-import static com.splunk.cloudfwd.PropertyKeys.DEFAULT_UNRESPONSIVE_MS;
-import static com.splunk.cloudfwd.PropertyKeys.HEALTH_POLL_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MAX_TOTAL_CHANNELS;
-import static com.splunk.cloudfwd.PropertyKeys.MIN_HEALTH_POLL_MS;
-import static com.splunk.cloudfwd.PropertyKeys.REQUIRED_KEYS;
-import static com.splunk.cloudfwd.PropertyKeys.UNRESPONSIVE_MS;
 import com.splunk.cloudfwd.impl.ConnectionImpl;
+import com.splunk.cloudfwd.impl.EventBatchImpl;
 import com.splunk.cloudfwd.impl.http.Endpoints;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Properties;
 import org.apache.commons.lang.StringUtils;
+
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.splunk.cloudfwd.PropertyKeys.*;
 
 /**
  *
  * @author ghendrey
  */
 public class ConnectionSettings {
-    protected final Logger LOG;
-    protected Properties defaultProps = new Properties();
-    //protected Properties overrides;
+    protected Logger LOG;
+    protected Logger GENERIC_LOG;
+    protected ConnectionSettings overrides;
     protected ConnectionImpl connection;
 
-    public ConnectionSettings(Connection c, Properties overrides) {
-        //this.overrides = overrides;
-        this.connection = (ConnectionImpl)c;
-        this.LOG = this.connection.getLogger(ConnectionSettings.class.getName());
-        this.parsePropertiesFile(overrides);
+    @JsonProperty("url")
+    private String url;
+
+    @JsonProperty("splunk_hec_token")
+    private String splunkHecToken;
+
+    @JsonProperty("splunk_hec_host")
+    private String splunkHecHost;
+
+    @JsonProperty("splunk_hec_index")
+    private String splunkHecIndex;
+
+    @JsonProperty("splunk_hec_source")
+    private String splunkHecSource;
+    
+    @JsonProperty("splunk_hec_sourcetype")
+    private String splunkHecSourcetype;
+    
+    @JsonProperty("ssl_cert_hostname_regex")
+    private String sslCertHostnameRegex;
+
+    @JsonProperty("hec_endpoint_type")
+    private String hecEndpointType = DEFAULT_HEC_ENDPOINT_TYPE;
+    
+    @JsonProperty("enable_checkpoints")
+    private Boolean enableCheckpoints = DEFAULT_ENABLE_CHECKPOINTS;
+
+    @JsonProperty("disable_certificate_validation")
+    private Boolean disableCertificateValidation = false;
+
+    @JsonProperty("channels_per_dest")
+    private int channelsPerDest = DEFAULT_CHANNELS_PER_DESTINATION;
+
+    @JsonProperty("mock_http")
+    private Boolean mockHttp = false;
+
+    @JsonProperty("enabled")
+    private Boolean testPropertiesEnabled;
+
+    @JsonProperty("unresponsive_channel_decom_ms")
+    private long unresponsiveChannelDecomMS = DEFAULT_UNRESPONSIVE_MS;
+
+    @JsonProperty("max_total_channels")
+    private int maxTotalChannels = DEFAULT_MAX_TOTAL_CHANNELS;
+
+    @JsonProperty("max_unacked_per_channel")
+    private int maxUnackedPerChannel = DEFAULT_MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL;
+
+    @JsonProperty("event_batch_size")
+    private int eventBatchSize = DEFAULT_EVENT_BATCH_SIZE;
+
+    @JsonProperty("ack_poll_ms")
+    private long ackPollMS = DEFAULT_ACK_POLL_MS;
+
+    @JsonProperty("health_poll_ms")
+    private long healthPollMS = DEFAULT_HEALTH_POLL_MS;
+
+    @JsonProperty("channel_decom_ms")
+    private long channelDecomMS = DEFAULT_DECOM_MS;
+    
+    @JsonProperty("channel_quiesce_timeout_ms")
+    private long channelQuiesceTimeoutMS = DEFAULT_CHANNEL_QUIESCE_TIMEOUT_MS;
+
+    @JsonProperty("ack_timeout_ms")
+    private long ackTimeoutMS = DEFAULT_ACK_TIMEOUT_MS;
+
+    @JsonProperty("blocking_timeout_ms")
+    private long blockingTimeoutMS = DEFAULT_BLOCKING_TIMEOUT_MS;
+
+    @JsonProperty("mock_http_classname")
+    private String mockHttpClassname;
+    
+    @JsonProperty("preflight_timeout")
+    private long preFlightTimeoutMS = DEFAULT_PREFLIGHT_TIMEOUT_MS;
+
+    @JsonProperty("ssl_cert_content")
+    private String sslCertContent;
+
+    @JsonProperty("cloud_ssl_cert_content")
+    private String cloudSslCertContent;
+
+    @JsonProperty("enable_http_debug")
+    private Boolean enableHttpDebug = false;
+
+    @JsonProperty("max_retries")
+    private int maxRetries = DEFAULT_RETRIES;
+
+    @JsonProperty("max_preflight_retries")
+    private int maxPreflightTries = DEFAULT_PREFLIGHT_RETRIES;
+
+    public static PropertiesFileHelper fromPropsFile(String pathToFile) {
+        // use Jackson to populate this ConnectionSettings instance from file
+        JavaPropsMapper mapper = new JavaPropsMapper();
+        try {
+            InputStream inputStream = ConnectionSettings.class.getResourceAsStream(pathToFile);
+            if (inputStream != null) {
+                PropertiesFileHelper propertiesFileHelper = mapper.readValue(inputStream, PropertiesFileHelper.class);
+                return propertiesFileHelper;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Could not map Properties file to Java object - please check file path.", e);
+        }
+
+        return null;
     }
 
-    public ConnectionSettings(Connection c) {
-        this.connection = (ConnectionImpl)c;
-        this.LOG = this.connection.getLogger(ConnectionSettings.class.getName());
-        this.parsePropertiesFile(new Properties());
+    public void setConnection(Connection c) {
+        connection = (ConnectionImpl)c;
+        LOG = connection.getLogger(ConnectionSettings.class.getName());
     }
 
-    public void putProperty(String k, String v) {
-        this.defaultProps.put(k, v);
+    /* ***************************** UTIL ******************************* */
+
+    protected <T> T applyDefaultIfNull(T value, T defaultValue) {
+        return value == null ? defaultValue : value;
     }
+
+    /* ***************************** GETTERS ******************************* */
+    /*
+       If property value is undefined, then return the default. Otherwise, return property value.
+       If set, the property value has already been validated by the property setter at init of ConnectionImpl
+       when the cloudfwd.properties file or overrides object have been loaded into the defaultProps object.
+     */
+
 
     public List<URL> getUrls() {
-        return urlsStringToList(defaultProps.getProperty(
-                PropertyKeys.COLLECTOR_URI));
+        return urlsStringToList(url);
     }
 
-    // Compares if the first URL matches Cloud>Trail domain (cloud.splunk.com)
-    public boolean isCloudInstance() {
-        return getUrls().get(0).toString().trim().
-                matches("^.+\\.cloud\\.splunk\\.com.*$");
-    }
-
-    private int handleInt(String key, String defaultVal) {
-        int n = Integer.parseInt(defaultProps.getProperty(
-                key,defaultVal).trim());        
-        if (n < 1) {
-            int deflt = Integer.parseInt(defaultVal);
-            LOG.debug("{}, defaulting {} to {}", n, key, deflt);
-            return deflt;
-        } else {
-            return n;
-        }
-    }
-    
-    private long handleLong(String key, String defaultVal) {
-        long n = Long.parseLong(defaultProps.getProperty(
-                key,defaultVal).trim());        
-        if (n < 1) {
-            long deflt = Integer.parseInt(defaultVal);
-            LOG.debug("{}, defaulting {} to {}", n, key, deflt);
-            return deflt;
-        } else {
-            return n;
-        }
-    }    
-    
-    public int getChannelsPerDestination() {
-        return handleInt(CHANNELS_PER_DESTINATION, DEFAULT_CHANNELS_PER_DESTINATION);
-    }
-
-    public long getUnresponsiveChannelDecomMS() {
-        return handleLong(UNRESPONSIVE_MS, DEFAULT_UNRESPONSIVE_MS);
-    }
-
-    public long getAckPollMS() {
-        long interval = Long.parseLong(defaultProps.getProperty(
-                ACK_POLL_MS,
-                DEFAULT_ACK_POLL_MS).trim());
-        if (interval <= 0) {
-            long was = interval;
-            interval = PropertyKeys.MIN_ACK_POLL_MS;
-            LOG.debug("{}, defaulting {} to {}", was, ACK_POLL_MS,interval);  
-        }
-        return interval;
-    }
-
-    public long getHealthPollMS() {
-        long interval = Long.parseLong(defaultProps.getProperty(
-                HEALTH_POLL_MS,
-                DEFAULT_HEALTH_POLL_MS).trim());
-        if (interval <= 0) {
-            long was = interval;
-            interval = MIN_HEALTH_POLL_MS;
-            LOG.debug("{}, defaulting {} to {}", was, HEALTH_POLL_MS,interval);  
-        }
-        return interval;
-    }
-
-    public int getMaxTotalChannels() {
-        int max = Integer.parseInt(defaultProps.getProperty(
-                MAX_TOTAL_CHANNELS,
-                DEFAULT_MAX_TOTAL_CHANNELS).trim()); //default no limit
-        if (max < 1) {
-            int was = max;
-            max = Integer.MAX_VALUE; //effectively no limit by default
-            LOG.debug("{}, defaulting {} to {}", was, MAX_TOTAL_CHANNELS,max);              
-        }
-        return max;
-    }
-
-    public int getMaxUnackedEventBatchPerChannel() {
-        int max = Integer.parseInt(defaultProps.getProperty(
-                PropertyKeys.MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL,
-                PropertyKeys.DEFAULT_MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL).
-                trim());
-        if (max < PropertyKeys.MIN_UNACKED_EVENT_BATCHES_PER_CHANNEL) {
-            max = 10000;
-        }
-        return max;
-    }
-
-    public int getEventBatchSize() {
-        int max = Integer.parseInt(defaultProps.getProperty(
-                PropertyKeys.EVENT_BATCH_SIZE,
-                PropertyKeys.DEFAULT_EVENT_BATCH_SIZE).trim());
-        if (max < 1) {
-            max = PropertyKeys.MIN_EVENT_BATCH_SIZE;
-        }
-        return max;
-    }
-
-    public long getChannelDecomMS() {
-        long decomMs = Long.parseLong(defaultProps.getProperty(
-                PropertyKeys.CHANNEL_DECOM_MS,
-                PropertyKeys.DEFAULT_DECOM_MS).trim());
-        if (decomMs <= 1) {
-            return -1;
-        }
-        if (decomMs < PropertyKeys.MIN_DECOM_MS && !isMockHttp()) {
-            LOG.warn(
-                    "Ignoring setting for " + PropertyKeys.CHANNEL_DECOM_MS + " because it is less than minimum acceptable value: " + PropertyKeys.MIN_DECOM_MS);
-            decomMs = PropertyKeys.MIN_DECOM_MS;
-        }
-        return decomMs;
-    }
-    
-    public long getChannelQuiesceTimeoutMS() {
-        long timeout = Long.parseLong(defaultProps.getProperty(
-                PropertyKeys.CHANNEL_QUIESCE_TIMEOUT_MS,
-                PropertyKeys.DEFAULT_CHANNEL_QUIESCE_TIMEOUT_MS).trim());
-        if (timeout < PropertyKeys.MIN_CHANNEL_QUIESCE_TIMEOUT_MS && !isMockHttp()) {
-            LOG.warn(PropertyKeys.CHANNEL_QUIESCE_TIMEOUT_MS + 
-                    " was set to a potentially too-low value, reset to min value: " + timeout);
-            timeout = PropertyKeys.MIN_CHANNEL_QUIESCE_TIMEOUT_MS;
-        }
-        return timeout;
-    }
-
-    public long getAckTimeoutMS() {
-        long timeout = Long.parseLong(defaultProps.getProperty(
-                PropertyKeys.ACK_TIMEOUT_MS,
-                PropertyKeys.DEFAULT_ACK_TIMEOUT_MS).trim());
-        if (timeout <= 0) {
-            timeout = Long.MAX_VALUE;
-        } else if (timeout < PropertyKeys.MIN_ACK_TIMEOUT_MS) {
-            LOG.warn(
-                    PropertyKeys.ACK_TIMEOUT_MS + " was set to a potentially too-low value, reset to min value: " + timeout);
-        }
-        return timeout;
-    }
-    
-    public long getPreFlightTimeout() {
-        long timeout = Long.parseLong(defaultProps.getProperty(
-                PropertyKeys.PREFLIGHT_TIMEOUT_MS,
-                PropertyKeys.DEFAULT_PREFLIGHT_TIMEOUT_MS));
-        if (timeout <= 0) {
-            throw new IllegalArgumentException(
-                    PropertyKeys.PREFLIGHT_TIMEOUT_MS + " must be greater than zero.");
-        }
-        return timeout;
-    }
-
-    public long getBlockingTimeoutMS() {
-        long timeout = Long.parseLong(defaultProps.getProperty(
-                PropertyKeys.BLOCKING_TIMEOUT_MS,
-                PropertyKeys.DEFAULT_BLOCKING_TIMEOUT_MS).trim());
-        if (timeout < 0) {
-            throw new IllegalArgumentException(
-                    PropertyKeys.BLOCKING_TIMEOUT_MS + " must be positive.");
-        }
-        return timeout;
-    }
-
-    public Endpoints getSimulatedEndpoints() {
-        String classname = this.defaultProps.getProperty(
-                PropertyKeys.MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.SimulatedHECEndpoints");
-        try {
-            return (Endpoints) Class.forName(classname).newInstance();
-        } catch (Exception ex) {
-            LOG.error(ex.getMessage(), ex);
-            throw new RuntimeException(ex.getMessage(), ex);
-        }
-    }
-
-    public boolean isCertValidationDisabled() {
-        return Boolean.parseBoolean(this.defaultProps.getProperty(
-                PropertyKeys.DISABLE_CERT_VALIDATION,
-                "false").trim());
-    }
-
-    public boolean enabledHttpDebug() {
-        return Boolean.parseBoolean(this.defaultProps.getProperty(
-                PropertyKeys.ENABLE_HTTP_DEBUG,
-                "false").trim());
-    }
-
-    /**
-     *
-     * @return
-     */
-    public String getSSLCertContent() {
-        String certKey = PropertyKeys.SSL_CERT_CONTENT;
-        if (isCloudInstance()) {
-            certKey = PropertyKeys.CLOUD_SSL_CERT_CONTENT;
-        }
-
-        String sslCertContent = defaultProps.getProperty(certKey);
-        if (sslCertContent != null) {
-            return sslCertContent.trim();
-        }
-        return "";
-    }
-
-    public void enableHttpDebug() {
-        System.setProperty("org.apache.commons.logging.Log",
-                "org.apache.commons.logging.impl.SimpleLog");
-        System.setProperty("org.apache.commons.logging.simplelog.showdatetime",
-                "true");
-        System.setProperty(
-                "org.apache.commons.logging.simplelog.log.httpclient.wire.header",
-                "debug");
-        System.setProperty(
-                "org.apache.commons.logging.simplelog.log.org.apache.http",
-                "debug");
-    }
-
-    public int getMaxRetries() {
-        int max = Integer.parseInt(defaultProps.
-                getProperty(PropertyKeys.RETRIES,
-                        PropertyKeys.DEFAULT_RETRIES).trim());
-        if (max < 1) {
-            LOG.debug(PropertyKeys.RETRIES + ": unlimited");
-            max = Integer.MAX_VALUE;
-        }
-        return max;
-    }
-    
-    public int getMaxPreflightRetries() {
-        int max = Integer.parseInt(defaultProps.
-                getProperty(PropertyKeys.PREFLIGHT_RETRIES,
-                        PropertyKeys.DEFAULT_PREFLIGHT_RETRIES).trim());
-        if (max < 1) {
-            LOG.debug(PropertyKeys.PREFLIGHT_RETRIES + ": unlimited");
-            max = Integer.MAX_VALUE;
-        }
-        return max;
-    }    
-
-    public boolean isCheckpointEnabled() {
-        return Boolean.parseBoolean(this.defaultProps.getProperty(
-                PropertyKeys.ENABLE_CHECKPOINTS,
-                PropertyKeys.DEFAULT_ENABLE_CHECKPOINTS).trim());
-    }
-
-    public ConnectionImpl.HecEndpoint getHecEndpointType() {
-        ConnectionImpl.HecEndpoint endpoint;
-        String type = defaultProps.getProperty(PropertyKeys.HEC_ENDPOINT_TYPE,
-                PropertyKeys.DEFAULT_HEC_ENDPOINT_TYPE).trim();
-        if (type.equals("raw")) {
-            endpoint = ConnectionImpl.HecEndpoint.RAW_EVENTS_ENDPOINT;
-        } else if (type.equals("event")) {
-            endpoint = ConnectionImpl.HecEndpoint.STRUCTURED_EVENTS_ENDPOINT;
-        } else {
-            LOG.warn(
-                    "Unrecognized HEC Endpoint type. Defaulting to " + PropertyKeys.DEFAULT_HEC_ENDPOINT_TYPE + ". See PropertyKeys.HEC_ENDPOINT_TYPE.");
-            endpoint = ConnectionImpl.HecEndpoint.RAW_EVENTS_ENDPOINT;
-        }
-        return endpoint;
-    }
-
-    private  void setHecEndpointType(String type) {
-        if(!type.equals("raw") && !type.equals("event")){
-            throw new HecConnectionStateException("Unsupported value for "+PropertyKeys.HEC_ENDPOINT_TYPE+". Should be [raw|event].", HecConnectionStateException.Type.CONFIGURATION_EXCEPTION);
-        }
-        defaultProps.put(PropertyKeys.HEC_ENDPOINT_TYPE, type);
-    }
-    
-    public void setHecEndpointType(
-            ConnectionImpl.HecEndpoint type) {
-        if (type == ConnectionImpl.HecEndpoint.STRUCTURED_EVENTS_ENDPOINT) {
-            defaultProps.put(PropertyKeys.HEC_ENDPOINT_TYPE, "event");
-        } else {
-            defaultProps.put(PropertyKeys.HEC_ENDPOINT_TYPE, "raw");
-        }
-    }
-
-    public Properties getDiff(Properties props) {
-        Properties diff = new Properties();
-        diff.putAll(defaultProps);
-        diff.putAll(props);
-        diff.entrySet().removeAll(defaultProps.entrySet());
-        return diff;
-    }
-
-    public String getToken() {
-        if (defaultProps.getProperty(PropertyKeys.TOKEN) == null) {
-            throw new HecConnectionStateException(
-                    "HEC token missing from Connection configuration. " + "See PropertyKeys.TOKEN",
-                    HecConnectionStateException.Type.CONFIGURATION_EXCEPTION);
-        }
-        return defaultProps.getProperty(PropertyKeys.TOKEN);
-    }
-
-    public String getHost() {
-        return defaultProps.getProperty(PropertyKeys.HOST);
-    }
-
-    public String getSource() {
-        return defaultProps.getProperty(PropertyKeys.SOURCE);
-    }
-
-    public String getSourcetype() {
-        return defaultProps.getProperty(PropertyKeys.SOURCETYPE);
-    }
-
-    public String getIndex() {
-        return defaultProps.getProperty(PropertyKeys.INDEX);
+    public String getUrlString() {
+        return url;
     }
 
     protected List<URL> urlsStringToList(String urlsListAsString) {
@@ -393,188 +193,18 @@ public class ConnectionSettings {
                 url =getUrlWithAutoAssignedPorts(urlString);
                 urlList.add(url);
             } catch (MalformedURLException ex) {
-                String msg = "url:'"+urlString+"',  "+ ex.getLocalizedMessage() ;
+                String msg = "url:'"+urlString+"',  "+ ex.getLocalizedMessage();
                 HecConnectionStateException e = new HecConnectionStateException(msg,
-                    HecConnectionStateException.Type.CONFIGURATION_EXCEPTION, ex);
-                connection.getCallbacks().systemError(e);
-                LOG.error(msg);
+                        HecConnectionStateException.Type.CONFIGURATION_EXCEPTION, ex);
+                if (connection != null) {
+                    connection.getCallbacks().systemError(e);
+                }
+                getLog().error(e.getMessage(), e);
+                throw e;
             }
         }
         urlList.sort(Comparator.comparing(URL::toString));
         return urlList;
-    }
-
-    protected boolean isMockHttp() {
-        return Boolean.parseBoolean(this.defaultProps.getProperty(
-                PropertyKeys.MOCK_HTTP_KEY,
-                "false").trim());
-    }
-
-    /**
-     * @param numChars the size of the EventBatchImpl in characters (not bytes)
-     */
-    public void setEventBatchSize(int numChars) {
-        putProperty(PropertyKeys.EVENT_BATCH_SIZE, String.
-                valueOf(numChars));
-    }
-
-    /**
-     * Use this method to change multiple settings on the connection. See
-     * PropertyKeys class for more information.
-     *
-     * @param props
-     */
-    public void setProperties(Properties props) throws UnknownHostException {
-        Properties diffs = getDiff(props);
-        for (String key : diffs.stringPropertyNames()) {
-            String val = diffs.getProperty(key);
-            switch (key) {
-                case PropertyKeys.ACK_TIMEOUT_MS:
-                    setAckTimeoutMS(Long.parseLong(val));
-                    break;
-                case PropertyKeys.COLLECTOR_URI:
-                    setUrls(val);
-                    break;
-                case PropertyKeys.TOKEN:
-                    setToken(val);
-                    break;
-                case PropertyKeys.HEC_ENDPOINT_TYPE:
-                    setHecEndpointType(val);
-                    break;
-                case PropertyKeys.HOST:
-                    setHost(val);
-                    break;
-                case PropertyKeys.INDEX:
-                    setIndex(val);
-                    break;
-                case PropertyKeys.SOURCE:
-                    setSource(val);
-                    break;
-                case PropertyKeys.SOURCETYPE:
-                    setSourcetype(val);
-                    break;
-                default:
-                    LOG.error("Attempt to change property not supported: " + key);
-            }
-        }
-    }
-
-    /**
-     * Set event acknowledgement timeout. See PropertyKeys.ACK_TIMEOUT_MS for
-     * more information.
-     *
-     * @param ms
-     */
-    public synchronized void setAckTimeoutMS(long ms) {
-        if (ms != getAckTimeoutMS()) {
-            putProperty(ACK_TIMEOUT_MS, String.valueOf(ms));
-            connection.getTimeoutChecker().setTimeout(ms);
-        }
-    }
-
-      /**
-   * Set Http Event Collector token to use.
-   * May take up to PropertyKeys.CHANNEL_DECOM_MS milliseconds
-   * to go into effect.
-   * @param token
-   */
-  public void setToken(String token) {
-    if (!token.equals(getToken())) {
-      putProperty(PropertyKeys.TOKEN, token);
-      checkAndRefreshChannels();
-    }
-  }
-
-  /**
-   * Set urls to send to. See PropertyKeys.COLLECTOR_URI
-   * for more information.
-   * @param urls comma-separated list of urls
-   */
-  public void setUrls(String urls) {
-    if(!urls.equals(defaultProps.getProperty(PropertyKeys.COLLECTOR_URI))){
-       // a single url or a list of comma separated urls
-      putProperty(PropertyKeys.COLLECTOR_URI, urls);
-      checkAndRefreshChannels();
-    }
-  }
-
-  /**
-   * Checking if LoadBalancer exists before refreshing channels
-   */
-  private void checkAndRefreshChannels() {
-      if (connection.getLoadBalancer() != null) {
-          connection.getLoadBalancer().refreshChannels();
-      }
-  }
-
-    /**
-     * Set Host value for the data feed
-     * @param host Host value for the data feed
-     */
-    public void setHost(String host) {
-        if (!StringUtils.isEmpty(host) && !host.equals(getHost())) {
-            putProperty(PropertyKeys.HOST, host);
-        }
-    }
-
-    /**
-     * Set Splunk index in which the data feed is stored
-     * @param index The Splunk index in which the data feed is stored
-     */
-    public void setIndex(String index) {
-        if (!StringUtils.isEmpty(index) && !index.equals(getIndex())) {
-            putProperty(PropertyKeys.INDEX, index);
-        }
-    }
-
-    /**
-     * Set the source of the data feed
-     * @param source The source of the data feed
-     */
-    public void setSource(String source) {
-        if (!StringUtils.isEmpty(source) && !source.equals(getSource())) {
-            putProperty(PropertyKeys.SOURCE, source);
-        }
-    }
-
-    /**
-     * Set the source type of events of data feed
-     * @param sourcetype The source type of events of data feed
-     */
-    public void setSourcetype(String sourcetype) {
-        if (!StringUtils.isEmpty(sourcetype) && !sourcetype.equals(getSourcetype())) {
-            putProperty(PropertyKeys.SOURCETYPE, sourcetype);
-        }
-    }
-  
-    // All properties are populated by following order of precedence: 1) overrides, 2) cloudfwd.properties, then 3) defaults.
-    private void parsePropertiesFile(Properties overrides) {
-        try {
-            InputStream is = getClass().getResourceAsStream("/cloudfwd.properties");
-            if (is != null) {
-                defaultProps.load(is);
-            }
-
-            if (overrides != null) {
-                defaultProps.putAll(overrides);
-            }
-
-            // If required properties are missing from cloudfwd.properties, overrides, and defaults, then throw exception.
-            for (String key : REQUIRED_KEYS) {
-                if (this.defaultProps.getProperty(key) == null) {
-                    throw new HecMissingPropertiesException(
-                            "Missing required key: " + key);
-                }
-            }
-
-            // For any non-required properties, we allow them to remain null if they are not present in overrides
-            // or cloudfwd.properties, because the property getters below will return the default values.
-        } catch (IOException ex) {
-            LOG.error("Problem loading cloudfwd.properties: {}", ex.getMessage());
-            throw new HecIllegalStateException("Problem loading cloudfwd.properties",
-                    HecIllegalStateException.Type.CANNOT_LOAD_PROPERTIES);
-        }
-
     }
 
     private URL getUrlWithAutoAssignedPorts(String urlString) throws MalformedURLException {
@@ -585,11 +215,463 @@ public class ConnectionSettings {
         }
         if (url.getPort() == -1) {
             int port = 443;
-            LOG.warn("No port provided for url: " + urlString.trim()
+            getLog().warn("No port provided for url: " + urlString.trim()
                     + ". Defaulting to port " + port);
             return new URL(url.getProtocol(), url.getHost(), port, url.getFile());
         }
         return url;
     }
+
+    // Compares if the first URL matches Cloud>Trail domain (cloud.splunk.com)
+    public boolean isCloudInstance() {
+        return getUrls().get(0).toString().trim().
+                matches("^.+\\.cloud\\.splunk\\.com.*$");
+    }
+
+    public int getChannelsPerDestination() {
+        return applyDefaultIfNull(channelsPerDest, DEFAULT_CHANNELS_PER_DESTINATION);
+    }
+
+    public long getUnresponsiveChannelDecomMS() {
+        return applyDefaultIfNull(unresponsiveChannelDecomMS, DEFAULT_UNRESPONSIVE_MS);
+    }
+
+    public long getAckPollMS() {
+        return applyDefaultIfNull(ackPollMS, DEFAULT_ACK_POLL_MS);
+    }
+
+    public long getHealthPollMS() {
+        return applyDefaultIfNull(healthPollMS, DEFAULT_HEALTH_POLL_MS);
+    }
+
+    public int getMaxTotalChannels() {
+        return applyDefaultIfNull(maxTotalChannels, DEFAULT_MAX_TOTAL_CHANNELS);
+    }
+
+    public int getMaxUnackedEventBatchPerChannel() {
+        return applyDefaultIfNull(maxUnackedPerChannel, DEFAULT_MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL);
+    }
+
+    public int getEventBatchSize() {
+        return applyDefaultIfNull(eventBatchSize, DEFAULT_EVENT_BATCH_SIZE);
+    }
+
+    public long getChannelDecomMS() {
+        return applyDefaultIfNull(channelDecomMS, DEFAULT_DECOM_MS);
+    }
+    
+    public long getChannelQuiesceTimeoutMS() {
+        return applyDefaultIfNull(channelQuiesceTimeoutMS, DEFAULT_CHANNEL_QUIESCE_TIMEOUT_MS);
+    }
+
+    public long getAckTimeoutMS() {
+        return applyDefaultIfNull(ackTimeoutMS, DEFAULT_ACK_TIMEOUT_MS);
+    }
+
+    public long getBlockingTimeoutMS() {
+        return applyDefaultIfNull(blockingTimeoutMS, DEFAULT_BLOCKING_TIMEOUT_MS);
+    }
+    
+    public String getMockHttpClassname() {
+        return applyDefaultIfNull(mockHttpClassname, "com.splunk.cloudfwd.impl.sim.SimulatedHECEndpoints");
+    }
+
+    public Endpoints getSimulatedEndpoints() {
+        try {
+            return (Endpoints) Class.forName(getMockHttpClassname()).newInstance();
+        } catch (Exception ex) {
+            getLog().error(ex.getMessage(), ex);
+            throw new RuntimeException(ex.getMessage(), ex);
+        }
+    }
+
+    public long getPreFlightTimeoutMS() {
+        return applyDefaultIfNull(preFlightTimeoutMS, DEFAULT_PREFLIGHT_TIMEOUT_MS);
+    }
+
+    public boolean isCertValidationDisabled() {
+        return applyDefaultIfNull(disableCertificateValidation, false);
+    }
+
+    public boolean isHttpDebugEnabled() {
+        return applyDefaultIfNull(enableHttpDebug, false);
+    }
+
+    public boolean isCheckpointEnabled() {
+        return applyDefaultIfNull(enableCheckpoints, DEFAULT_ENABLE_CHECKPOINTS);
+    }
+
+    public String getSSLCertContent() {
+        String certKey = sslCertContent;
+        if (isCloudInstance()) {
+            certKey = cloudSslCertContent;
+        }
+
+        if (certKey != null) {
+            return certKey.trim();
+        }
+        return "";
+    }
+
+    public int getMaxRetries() {
+        return applyDefaultIfNull(maxRetries, DEFAULT_RETRIES);
+    }
+
+    public int getMaxPreflightRetries() {
+        return applyDefaultIfNull(maxPreflightTries, DEFAULT_PREFLIGHT_RETRIES);
+    }
+
+    public ConnectionImpl.HecEndpoint getHecEndpointType() {
+        ConnectionImpl.HecEndpoint endpoint;
+        String type = applyDefaultIfNull(hecEndpointType, DEFAULT_HEC_ENDPOINT_TYPE);
+        if (type.equals("raw")) {
+            endpoint = ConnectionImpl.HecEndpoint.RAW_EVENTS_ENDPOINT;
+        } else if (type.equals("event")) {
+            endpoint = ConnectionImpl.HecEndpoint.STRUCTURED_EVENTS_ENDPOINT;
+        } else {
+            getLog().warn(
+                    "Unrecognized HEC Endpoint type. Defaulting to " + PropertyKeys.DEFAULT_HEC_ENDPOINT_TYPE + ". See PropertyKeys.HEC_ENDPOINT_TYPE.");
+            endpoint = ConnectionImpl.HecEndpoint.RAW_EVENTS_ENDPOINT;
+        }
+        return endpoint;
+    }
+
+    public String getToken() {
+        if (splunkHecToken == null) {
+            throw new HecConnectionStateException(
+                    "HEC token missing from Connection configuration. " + "See PropertyKeys.TOKEN",
+                    HecConnectionStateException.Type.CONFIGURATION_EXCEPTION);
+        }
+        return splunkHecToken;
+    }
+
+    public boolean isMockHttp() {
+        return applyDefaultIfNull(mockHttp, false);
+    }
+
+
+    public Boolean getTestPropertiesEnabled() {
+        return applyDefaultIfNull(testPropertiesEnabled, false);
+    }
+
+    public String getHost() {
+        return splunkHecHost;
+    }
+
+    public String getSource() {
+        return splunkHecSource;
+    }
+
+    public String getSourcetype() {
+        return splunkHecSourcetype;
+    }
+
+    public String getIndex() {
+        return splunkHecIndex;
+    }
+
+    /* ***************************** SETTERS ******************************* */
+    // Setters should not throw Exceptions or call callbacks on Connection instance
+    // because they may be called before the Connection is instantiated.
+    // Any setter behavior that should happen on the Connection instance should be defined
+    // in ConnectionSettings > setConnection() method (or in Connections > create())
+
+    public void setChannelsPerDestination(int numChannels) {
+        if (numChannels < 1) {
+            int was = numChannels;
+            numChannels = DEFAULT_CHANNELS_PER_DESTINATION;
+            getLog().debug("{}, defaulting {} to {}", was, CHANNELS_PER_DESTINATION, numChannels);
+            channelsPerDest = DEFAULT_CHANNELS_PER_DESTINATION;
+        }
+        channelsPerDest = numChannels;
+    }
+
+    public void setUnresponsiveMS(long decomMS) {
+        if (decomMS < 1) {
+            long was = decomMS;
+            decomMS = DEFAULT_UNRESPONSIVE_MS;
+            getLog().debug("{}, defaulting {} to {}", was, UNRESPONSIVE_MS, decomMS);
+            unresponsiveChannelDecomMS = DEFAULT_UNRESPONSIVE_MS;
+        }
+        unresponsiveChannelDecomMS = decomMS;
+    }
+
+    public void setAckPollMS(long pollMS) {
+        if (pollMS <= 0) {
+            long was = pollMS;
+            pollMS = MIN_ACK_POLL_MS;
+            getLog().debug("{}, defaulting {} to smallest allowed value of {}", was, ACK_POLL_MS, pollMS);
+        }
+        ackPollMS = pollMS;
+    }
+
+    public void setHealthPollMS(long pollMS) {
+        if (pollMS <= 0) {
+            long was = pollMS;
+            pollMS = MIN_HEALTH_POLL_MS;
+            getLog().debug("{}, defaulting {} to smallest allowed value {}", was, HEALTH_POLL_MS, pollMS);
+        }
+        healthPollMS = pollMS;
+    }
+
+    public void setMaxTotalChannels(int totalChannels) {
+        if (totalChannels < 1) {
+            int was = totalChannels;
+            totalChannels = Integer.MAX_VALUE; //effectively no limit by default
+            getLog().debug("{}, defaulting {} to no-limit {}", was, MAX_TOTAL_CHANNELS, totalChannels);
+        }
+        maxTotalChannels = totalChannels;
+    }
+
+    public void setMaxUnackedEventBatchPerChannel(int batchesPerChannel) {
+        int max = 10000;
+        if (batchesPerChannel < MIN_UNACKED_EVENT_BATCHES_PER_CHANNEL) {
+            int was = batchesPerChannel;
+            batchesPerChannel = max;
+            getLog().debug("{}, defaulting {} to no limit {}", was, MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL, batchesPerChannel);
+        }
+        maxUnackedPerChannel = batchesPerChannel;
+    }
+
+    /**
+     * @param numChars the size of the EventBatchImpl in characters (not bytes)
+     */
+    public void setEventBatchSize(int numChars) {
+        if (numChars < 1) {
+            int was = numChars;
+            numChars = MIN_EVENT_BATCH_SIZE;
+            getLog().debug("{}, defaulting {} to smallest allowed value {}", was, EVENT_BATCH_SIZE, numChars);
+        }
+        eventBatchSize = numChars;
+    }
+
+    public void setChannelDecomMS(long decomMS) {
+        if (decomMS <= 1) {
+            long was = decomMS;
+            decomMS = -1;
+            getLog().debug("{}, defaulting {} to no-limit {}", was, CHANNEL_DECOM_MS, decomMS);
+        } else if (decomMS < MIN_DECOM_MS && !isMockHttp()) {
+            getLog().warn(
+                    "Ignoring setting for " + CHANNEL_DECOM_MS + " because it is less than minimum acceptable value: " + MIN_DECOM_MS);
+            decomMS = MIN_DECOM_MS;
+        }
+        channelDecomMS = decomMS;
+    }
+    
+    public void setChannelQuiesceTimeoutMS(long timeoutMS) {
+        if (timeoutMS < PropertyKeys.MIN_CHANNEL_QUIESCE_TIMEOUT_MS && !isMockHttp()) {
+            LOG.warn(PropertyKeys.CHANNEL_QUIESCE_TIMEOUT_MS +
+                    " was set to a potentially too-low value, reset to min value: " + timeoutMS);
+            channelQuiesceTimeoutMS = MIN_CHANNEL_QUIESCE_TIMEOUT_MS;
+        } else {
+            channelQuiesceTimeoutMS = timeoutMS;
+        }
+    }
+
+    public void setAckTimeoutMS(long timeoutMS) {
+        if (timeoutMS != getAckTimeoutMS()) {
+            if (timeoutMS <= 0) {
+                long was = timeoutMS;
+                timeoutMS = Long.MAX_VALUE;
+                getLog().debug("{}, defaulting {} to maximum allowed value {}", was, ACK_TIMEOUT_MS, timeoutMS);
+            } else if (timeoutMS < MIN_ACK_TIMEOUT_MS && !isMockHttp()) {
+                getLog().warn(ACK_TIMEOUT_MS + " was set to a potentially too-low value, reset to min value: " + timeoutMS);
+                timeoutMS = MIN_ACK_TIMEOUT_MS;
+            }
+            ackTimeoutMS = timeoutMS;
+            if (connection != null) {
+                connection.getTimeoutChecker().setTimeout();
+            }
+        }
+    }
+
+    public void setBlockingTimeoutMS(long timeoutMS) {
+        if (timeoutMS < 0) {
+            throw new IllegalArgumentException(BLOCKING_TIMEOUT_MS + " must be positive.");
+        }
+        blockingTimeoutMS = timeoutMS;
+    }
+
+    public void setMockHttpClassname(String endpoints) {
+        mockHttpClassname = endpoints;
+    }
+    
+    public void setPreFlightTimeoutMS(long timeoutMS) {
+        if (timeoutMS <= 0) {
+            throw new IllegalArgumentException(
+                    PropertyKeys.PREFLIGHT_TIMEOUT_MS + " must be greater than zero.");
+        }
+        preFlightTimeoutMS = timeoutMS;
+    }
+
+    public void disableCertValidation() {
+        disableCertificateValidation = true;
+    }
+    
+    public void enableCertValidation() {
+        disableCertificateValidation = false;
+    }
+
+    public void setHttpDebugEnabled(Boolean mode) {
+        if (mode == true) {
+            System.setProperty("org.apache.commons.logging.Log",
+                    "org.apache.commons.logging.impl.SimpleLog");
+            System.setProperty("org.apache.commons.logging.simplelog.showdatetime",
+                    "true");
+            System.setProperty(
+                    "org.apache.commons.logging.simplelog.log.httpclient.wire.header",
+                    "debug");
+            System.setProperty(
+                    "org.apache.commons.logging.simplelog.log.org.apache.http",
+                    "debug");
+        }
+        this.enableHttpDebug = mode;
+    }
+
+    public void setCheckpointEnabled(Boolean mode) {
+        enableCheckpoints = mode;
+    }
+
+    public void setSSLCertContent(String cert) {
+        if (isCloudInstance()) {
+            cloudSslCertContent = cert;
+        } else {
+            sslCertContent = cert;
+        }
+    }
+
+    public void setMaxRetries(int retries) {
+        if (retries < 1) {
+            int was = retries;
+            retries = Integer.MAX_VALUE;
+            getLog().debug("{}, defaulting {} to maximum allowed value {}", was, RETRIES, retries);
+        }
+        maxRetries = retries;
+    }
+
+    public void setMaxPreflightRetries(int retries) {
+        if (retries < 1) {
+            int was = retries;
+            retries = Integer.MAX_VALUE;
+            getLog().debug("{}, defaulting {} to maximum allowed value {}", was, PREFLIGHT_RETRIES, retries);
+        }
+        maxPreflightTries = retries;
+    }
+
+    public void setHecEndpointType(ConnectionImpl.HecEndpoint type) {
+        String endpoint;
+        if (type == ConnectionImpl.HecEndpoint.STRUCTURED_EVENTS_ENDPOINT) {
+            endpoint = "event";
+        } else if (type == ConnectionImpl.HecEndpoint.RAW_EVENTS_ENDPOINT) {
+            endpoint = "raw";
+        } else {
+            getLog().warn(
+                    "Unrecognized HEC Endpoint type. Defaulting to " + DEFAULT_HEC_ENDPOINT_TYPE + ". See PropertyKeys.HEC_ENDPOINT_TYPE.");
+            endpoint = DEFAULT_HEC_ENDPOINT_TYPE;
+        }
+        hecEndpointType = endpoint;
+    }
+
+    /**
+     * Set Http Event Collector token to use.
+     * May take up to PropertyKeys.CHANNEL_DECOM_MS milliseconds
+     * to go into effect.
+     * @param token
+     */
+    public void setToken(String token) {
+        if (!token.equals(getToken())) {
+            splunkHecToken = token;
+            checkAndRefreshChannels();
+        }
+    }
+
+    public void setMockHttp(Boolean mode) {
+        mockHttp = mode;
+    }
+
+  /**
+   * Set urls to send to. See PropertyKeys.COLLECTOR_URI
+   * for more information.
+   * @param urls comma-separated list of urls
+   */
+  public void setUrls(String urls) {
+      if (connection != null && !urlsStringToList(urls).equals(getUrls())) {
+          url = urls;
+          checkAndRefreshChannels();
+      } else {
+          url = urls;
+      }
+  }
+
+  public void setTestPropertiesEnabled(Boolean enabled) {
+      testPropertiesEnabled = enabled;
+  }
+  
+    /**
+     * Set Host value for the data feed
+     * @param host Host value for the data feed
+     */
+  public void setHost(String host) {
+      if (!StringUtils.isEmpty(host) && !host.equals(getHost())) {
+          splunkHecHost = host;
+          checkAndRefreshChannels();
+      }
+  }
+
+    /**
+     * Set Splunk index in which the data feed is stored
+     * @param index The Splunk index in which the data feed is stored
+     */
+  public void setIndex(String index) {
+      if (!StringUtils.isEmpty(index) && !index.equals(getIndex())) {
+          splunkHecIndex = index;
+          checkAndRefreshChannels();
+      }
+  }
+
+    /**
+     * Set the source of the data feed
+     * @param source The source of the data feed
+     */
+  public void setSource(String source) {
+      if (!StringUtils.isEmpty(source) && !source.equals(getSource())) {
+          splunkHecSource = source;
+          checkAndRefreshChannels();
+      }
+  }
+
+    /**
+     * Set the source type of events of data feed
+     * @param sourcetype The source type of events of data feed
+     */
+  public void setSourcetype(String sourcetype) {
+      if (!StringUtils.isEmpty(sourcetype) && !sourcetype.equals(getSourcetype())) {
+          splunkHecSourcetype = sourcetype;
+          checkAndRefreshChannels(); 
+      }
+  }
+  
+    /**
+     * Checking if LoadBalancer exists before refreshing channels
+     */
+    private void checkAndRefreshChannels() {
+        if (connection != null && connection.getLoadBalancer() != null) {
+            connection.getLoadBalancer().refreshChannels();
+        }
+    }
+
+    protected Logger getLog() {
+      if (this.connection != null) {
+          return LOG;
+      } else {
+          if (GENERIC_LOG == null) {
+              return LoggerFactory.getLogger(EventBatchImpl.class.getName());
+          }
+          return GENERIC_LOG;
+      }
+    }
+/*
+User should be able to init Connection using ConnectionSettings
+ */
 
 }

--- a/src/main/java/com/splunk/cloudfwd/ConnectionSettings.java
+++ b/src/main/java/com/splunk/cloudfwd/ConnectionSettings.java
@@ -200,7 +200,6 @@ public class ConnectionSettings {
                     connection.getCallbacks().systemError(e);
                 }
                 getLog().error(e.getMessage(), e);
-                throw e;
             }
         }
         urlList.sort(Comparator.comparing(URL::toString));

--- a/src/main/java/com/splunk/cloudfwd/Connections.java
+++ b/src/main/java/com/splunk/cloudfwd/Connections.java
@@ -15,9 +15,14 @@
  */
 package com.splunk.cloudfwd;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.splunk.cloudfwd.impl.ConnectionImpl;
-import java.io.IOException;
-import java.io.InputStream;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Properties;
 
 /**
@@ -26,49 +31,55 @@ import java.util.Properties;
  * @author ghendrey
  */
 public class Connections {
+    
+    private static Logger LOG = LoggerFactory.getLogger(Connections.class.getName());
 
     private Connections() {
 
     }
 
     public static Connection create(ConnectionCallbacks c) {
-        return create(c, new Properties());
+        return create(c, new ConnectionSettings());
     }
-
+    
     /**
      * When creating a connection, an attempt is made to check the server-side configurations of every channel managed by the 
      * load balancer. If any of the channels finds misconfigurations, such as HEC acknowldegements disabled, or invalid HEC
      * token, then an exception is thrown from Connections.create. This is 'fail fast' behavior designed to quickly expose 
      * serverside configuration issues.
-     * @param c The ConnectionCallbacks 
-     * @param p Properties that customize the Connection
+     * @param cb
+     * @param settings
      * @return
      */
-    public static Connection create(ConnectionCallbacks c, Properties p) {
-        return new ConnectionImpl(c, p);
+    public static Connection create(ConnectionCallbacks cb, ConnectionSettings settings) {
+        ConnectionImpl c = new ConnectionImpl(cb, settings);
+        Connections.setupConnection(c, (PropertiesFileHelper)settings);
+        return c;
     }
     
     /**
      * Creates a Connection with DefaultConnectionCallbacks
-     * @param p Properties that customize the Connection
+     * @param settings Properties that customize the Connection
      * @return
      */
-    public static Connection create(Properties p) {
-        return new ConnectionImpl(new DefaultConnectionCallbacks(), p);
-    }    
+    public static Connection create(ConnectionSettings settings) {
+        ConnectionImpl c = new ConnectionImpl(new DefaultConnectionCallbacks(), settings);
+        Connections.setupConnection(c, (PropertiesFileHelper) settings);
+        return c;
+    }   
     
-     /**
-     * Creates a Connection with DefaultConnectionCallbacks and default settings loaded from cloudfwd.properties
-     * @param pProperties that customize the Connection
-     * @return
-     */
-    public static Connection create() throws IOException {
-        Properties p = new Properties();
-        try(InputStream is = Connection.class.getResourceAsStream("cloudfwd.properties");){
-            p.load(is);
-            return new ConnectionImpl(new DefaultConnectionCallbacks(), p);
+    private static void setupConnection(ConnectionImpl c, PropertiesFileHelper settings) {
+        LOG = c.getLogger(Connections.class.getName());
+        settings.setConnection(c);
+
+        // Print out ConnectionSettings properties
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        try {
+            LOG.info("ConnectionSettings properties are:\n" + mapper.writerWithDefaultPrettyPrinter().writeValueAsString(settings));
+        } catch (JsonProcessingException e) {
+            LOG.error("Could not pretty print ConnectionSettings properties");
         }
-    }    
+    }
     
-   
 }

--- a/src/main/java/com/splunk/cloudfwd/PropertyKeys.java
+++ b/src/main/java/com/splunk/cloudfwd/PropertyKeys.java
@@ -35,7 +35,7 @@ public class PropertyKeys {
    * front of Splunk cluster. This can also be a comma-separated list of urls.
    * Example: https://127.0.0.1:8088
    */
-  public static final String COLLECTOR_URI = "splunk_hec_url";
+  public static final String COLLECTOR_URI = "url";
 
   /**
    * Host value for the data feed
@@ -92,7 +92,7 @@ public class PropertyKeys {
    * If true, disables certificate validation and allows sending to non-HTTPs
    * endpoints. Defaults to false.
    */
-  public static final String DISABLE_CERT_VALIDATION = "disableCertificateValidation";
+  public static final String DISABLE_CERT_VALIDATION = "disable_certificate_validation";
 
   /**
    * Integer number of channels per internet socket address destination. Event
@@ -258,82 +258,76 @@ public class PropertyKeys {
   public static final String PREFLIGHT_TIMEOUT_MS = "preflight_timeout";
 
 
-  /* **************************** REQUIRED KEYS ************************* */
-
-  // Connection object cannot be instantiated without these keys being provided, either in overrides or cloudfwd.properties
-  public static final String[] REQUIRED_KEYS = {TOKEN, COLLECTOR_URI};
-
-
   /* **************************** DEFAULTS ************************* */
   /**
    * Default value for EVENT_BATCH_SIZE property.
    *
    * @see EVENT_BATCH_SIZE
    */
-  public static final String DEFAULT_EVENT_BATCH_SIZE = "32768"; //32k characters
+  public static final int DEFAULT_EVENT_BATCH_SIZE = 32768; //32k characters
 
   /**
    * Default value for ACK_POLL_MS property.
    *
    * @see ACK_POLL_MS
    */
-  public static final String DEFAULT_ACK_POLL_MS = "1000"; //1sec
+  public static final long DEFAULT_ACK_POLL_MS = 1000; //1sec
 
   /**
    * Default value for HEALTH_POLL_MS property.
    *
    * @see HEALTH_POLL_MS
    */
-  public static final String DEFAULT_HEALTH_POLL_MS = "1000";  //1 sec
+  public static final long DEFAULT_HEALTH_POLL_MS = 1000;  //1 sec
 
   /**
    * Default value for CHANNEL_DECOM_MS property.
    *
    * @see CHANNEL_DECOM_MS
    */
-  public static final String DEFAULT_DECOM_MS = "600000";   //10 min
+  public static final long DEFAULT_DECOM_MS = 600000;   //10 min
 
   /**
    * Default value for ACK_TIMEOUT_MS property.
    *
    * @see ACK_TIMEOUT_MS
    */
-  public static final String DEFAULT_ACK_TIMEOUT_MS = "300000"; //5 min
+  public static final long DEFAULT_ACK_TIMEOUT_MS = 300000; //5 min
 
   /**
    * Default value for BLOCKING_TIMEOUT_MS property.
    *
    * @see BLOCKING_TIMEOUT_MS
    */
-  public static final String DEFAULT_BLOCKING_TIMEOUT_MS = "60000"; //1 min   
+  public static final long DEFAULT_BLOCKING_TIMEOUT_MS = 60000; //1 min   
 
   /**
    * Default value for UNRESPONSIVE_MS property.
    *
    * @see UNRESPONSIVE_MS
    */
-  public static final String DEFAULT_UNRESPONSIVE_MS = "-1"; //disabled by default
+  public static final long DEFAULT_UNRESPONSIVE_MS = -1; //disabled by default
 
   /**
    * Default value for the RETRIES property.
    *
    * @see RETRIES
    */
-  public static final String DEFAULT_RETRIES = "10";
+  public static final int DEFAULT_RETRIES = 10;
   
  /**
    * Default value for the PREFLIGHT_RETRIES property.
    *
    * @see RETRIES
    */
-  public static final String DEFAULT_PREFLIGHT_RETRIES = "3";  
+  public static final int DEFAULT_PREFLIGHT_RETRIES = 3;  
 
   /**
    * Default value for the MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL property.
    *
    * @see MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL
    */
-  public static final String DEFAULT_MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL = "2";
+  public static final int DEFAULT_MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL = 2;
 
   /**
    * Default value for the MAX_TOTAL_CHANNELS property. This is interpreted as
@@ -341,14 +335,14 @@ public class PropertyKeys {
    *
    * @see MAX_TOTAL_CHANNELS
    */
-  public static final String DEFAULT_MAX_TOTAL_CHANNELS = "-1";
+  public static final int DEFAULT_MAX_TOTAL_CHANNELS = -1;
 
   /**
    * Default value for the CHANNELS_PER_DESTINATION property.
    *
    * @see CHANNELS_PER_DESTINATION
    */
-  public static final String DEFAULT_CHANNELS_PER_DESTINATION = "8";
+  public static final int DEFAULT_CHANNELS_PER_DESTINATION = 8;
 
   /**
    * Default value for the HEC_ENDPOINT_TYPE property.
@@ -364,14 +358,14 @@ public class PropertyKeys {
    * When disabled, the application does NOT have to send events in order of
    * monotonically increasing IDs.
    */
-  public static final String DEFAULT_ENABLE_CHECKPOINTS = "false";
+  public static final Boolean DEFAULT_ENABLE_CHECKPOINTS = false;
   
   /**
    * Channel Quiesce Timeout define how much time to wait for a channel to 
    * drain all events. Channel will be killed if not quiesced in the time.
    * @see CHANNEL_QUIESCE_TIMEOUT_MS
    */
-  public static final String DEFAULT_CHANNEL_QUIESCE_TIMEOUT_MS = "180000";
+  public static final long DEFAULT_CHANNEL_QUIESCE_TIMEOUT_MS = 180000;
 
 
   /**
@@ -379,7 +373,7 @@ public class PropertyKeys {
    *
    * @see PREFLIGHT_TIMEOUT_MS
    */
-  public static final String DEFAULT_PREFLIGHT_TIMEOUT_MS = "60000"; // 1 minute
+  public static final long DEFAULT_PREFLIGHT_TIMEOUT_MS = 60000; // 1 minute
 
 
   /* **************************** LIMITS ************************* */

--- a/src/main/java/com/splunk/cloudfwd/impl/http/HttpSender.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/HttpSender.java
@@ -33,18 +33,12 @@ import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 
-import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
-import java.util.Properties;
 import java.util.Set;
-//import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static com.splunk.cloudfwd.PropertyKeys.*;
-import com.splunk.cloudfwd.impl.util.LoadBalancer;
 import com.splunk.cloudfwd.impl.util.ThreadScheduler;
 import java.net.URISyntaxException;
-import java.util.logging.Level;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.utils.URIBuilder;
 
@@ -383,7 +377,7 @@ public final class HttpSender implements Endpoints, CookieClient {
         }; // make sure http client or simulator is started
         AcknowledgementTracker.AckRequest ackReq = hecIoMgr.getAckPollRequest();        
         if (ackReq.isEmpty()) {
-            LOG.trace("no ackIds to poll for om {}", getChannel());
+            LOG.trace("no ackIds to poll for on {}", getChannel());
           return;
         } else {        
           hecIoMgr.setAckPollInProgress(true);

--- a/src/main/java/com/splunk/cloudfwd/impl/util/HecChannel.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/HecChannel.java
@@ -43,8 +43,6 @@ import java.util.concurrent.ScheduledFuture;
 import javax.net.ssl.SSLException;
 import java.util.List;
 import java.util.concurrent.Future;
-import java.util.logging.Level;
-
 
 
 /**
@@ -83,7 +81,7 @@ public class HecChannel implements Closeable, LifecycleEventObserver {
     this.channelId = newChannelId();
     this.channelMetrics = new ChannelMetrics(c);
     this.channelMetrics.addObserver(this);
-    this.maxUnackedEvents = loadBalancer.getConnectionSettings().
+    this.maxUnackedEvents = loadBalancer.getPropertiesFileHelper().
             getMaxUnackedEventBatchPerChannel();
     this.memoizedToString = this.channelId + "@" + sender.getBaseUrl();
     LOG.info("constructing channel: {}", memoizedToString);
@@ -106,7 +104,7 @@ public class HecChannel implements Closeable, LifecycleEventObserver {
      * @return
      */
     public HecHealthImpl getHealth() {
-        if(!health.await(getConnetionSettings().getPreFlightTimeout(), TimeUnit.MILLISECONDS)){
+        if(!health.await(getConnectionSettings().getPreFlightTimeoutMS(), TimeUnit.MILLISECONDS)){
             preFlightTimeout();
         }
         return health;
@@ -149,14 +147,14 @@ public class HecChannel implements Closeable, LifecycleEventObserver {
 
 
     private void setupDeadChannelDetector() {
-        long unresponsiveDecomMS = getConnetionSettings(). getUnresponsiveChannelDecomMS();
+        long unresponsiveDecomMS = getConnectionSettings().getUnresponsiveChannelDecomMS();
         if (unresponsiveDecomMS > 0) {
             deadChannelDetector = new DeadChannelDetector(unresponsiveDecomMS);
             deadChannelDetector.start();
         }
     }
   
-  private ConnectionSettings getConnetionSettings(){
+  private ConnectionSettings getConnectionSettings(){
       return loadBalancer.getConnection().getSettings();
   }
 

--- a/src/main/java/com/splunk/cloudfwd/impl/util/TimeoutChecker.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/TimeoutChecker.java
@@ -52,14 +52,14 @@ public class TimeoutChecker implements EventTracker {
         this.connection = c;
     }
 
-    public void setTimeout(long ms) {
+    public void setTimeout() {
         //queisce();
         start();
     }
 
     private long getTimeoutMs() {
         //check for timeouts with a minimum frequency of 1 second
-        return connection.getSettings().getAckTimeoutMS();
+        return connection.getPropertiesFileHelper().getAckTimeoutMS();
     }
 
     //how often we should rip through the list and check for timeouts

--- a/src/test/java/com/splunk/cloudfwd/test/integration/AWSSourcetypeIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/AWSSourcetypeIT.java
@@ -15,6 +15,7 @@ package com.splunk.cloudfwd.test.integration;/*
  */
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.splunk.cloudfwd.*;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -34,7 +35,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -194,10 +194,9 @@ public class AWSSourcetypeIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties p = super.getProps();
-        p.put(PropertyKeys.TOKEN, createTestToken(null));
-        return p;
+    protected void setProps(PropertiesFileHelper settings) {
+        super.setProps(settings);
+        settings.setToken(createTestToken(null));
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/integration/AWSSourcetypeIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/AWSSourcetypeIT.java
@@ -194,8 +194,8 @@ public class AWSSourcetypeIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
-        super.setProps(settings);
+    protected void configureProps(PropertiesFileHelper settings) {
+        super.configureProps(settings);
         settings.setToken(createTestToken(null));
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/integration/AbstractReconciliationTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/AbstractReconciliationTest.java
@@ -4,10 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.splunk.cloudfwd.Connection;
 import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.PropertyKeys;
-import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.impl.http.HttpClientFactory;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.io.IOException;
 import java.util.*;
 
@@ -120,12 +119,10 @@ public abstract class AbstractReconciliationTest extends AbstractConnectionTest 
   }
 
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(PropertyKeys.MOCK_HTTP_KEY, "false");
-    props.put(PropertyKeys.EVENT_BATCH_SIZE, "16000");
-    props.put(PropertyKeys.TOKEN, createTestToken(getSourceType()));    
-    return props;
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setMockHttp(false);
+    settings.setEventBatchSize(16000);
+    settings.setToken(createTestToken(getSourceType()));
   }
   
   protected String getSourceType(){

--- a/src/test/java/com/splunk/cloudfwd/test/integration/AbstractReconciliationTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/AbstractReconciliationTest.java
@@ -119,7 +119,7 @@ public abstract class AbstractReconciliationTest extends AbstractConnectionTest 
   }
 
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setMockHttp(false);
     settings.setEventBatchSize(16000);
     settings.setToken(createTestToken(getSourceType()));

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ByteBufferEventsToWrongEndpointTestIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ByteBufferEventsToWrongEndpointTestIT.java
@@ -20,6 +20,7 @@ import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.UnvalidatedByteBufferEvent;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.integration.AbstractReconciliationTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import java.nio.ByteBuffer;
@@ -32,14 +33,12 @@ import org.junit.Test;
  */
 public class ByteBufferEventsToWrongEndpointTestIT extends AbstractReconciliationTest{
   @Override
-    protected Properties getProps() {
-    Properties props = super.getProps(); //inherit the propertues from ByteBufferEventTest
-    //intentionally direct text events to /events endpoint
-    props.put(PropertyKeys.HEC_ENDPOINT_TYPE, Connection.HecEndpoint.STRUCTURED_EVENTS_ENDPOINT);
-    props.put(PropertyKeys.EVENT_BATCH_SIZE,  "16000");
-    super.eventType = Event.Type.UNKNOWN; //meeans its a Unvalidated* event (we can't tell what content is in it)
-    return props;
-  }    
+  protected void setProps(PropertiesFileHelper settings) {
+      //intentionally direct text events to /events endpoint
+      settings.setHecEndpointType(Connection.HecEndpoint.STRUCTURED_EVENTS_ENDPOINT);
+      settings.setEventBatchSize(16000);
+      super.eventType = Event.Type.UNKNOWN; //meeans its a Unvalidated* event (we can't tell what content is in it)
+  }
     
   @Override
  protected BasicCallbacks getCallbacks() {

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ByteBufferEventsToWrongEndpointTestIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ByteBufferEventsToWrongEndpointTestIT.java
@@ -30,8 +30,8 @@ import org.junit.Test;
  */
 public class ByteBufferEventsToWrongEndpointTestIT extends AbstractReconciliationTest{
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
-      super.setProps(settings);
+  protected void configureProps(PropertiesFileHelper settings) {
+      super.configureProps(settings);
       //intentionally direct text events to /events endpoint
       settings.setHecEndpointType(Connection.HecEndpoint.STRUCTURED_EVENTS_ENDPOINT);
       settings.setEventBatchSize(16000);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ByteBufferEventsToWrongEndpointTestIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ByteBufferEventsToWrongEndpointTestIT.java
@@ -17,14 +17,11 @@ package com.splunk.cloudfwd.test.integration;
 
 import com.splunk.cloudfwd.Connection;
 import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.UnvalidatedByteBufferEvent;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
-import com.splunk.cloudfwd.test.integration.AbstractReconciliationTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import java.nio.ByteBuffer;
-import java.util.Properties;
 import org.junit.Test;
 
 /**
@@ -34,6 +31,7 @@ import org.junit.Test;
 public class ByteBufferEventsToWrongEndpointTestIT extends AbstractReconciliationTest{
   @Override
   protected void setProps(PropertiesFileHelper settings) {
+      super.setProps(settings);
       //intentionally direct text events to /events endpoint
       settings.setHecEndpointType(Connection.HecEndpoint.STRUCTURED_EVENTS_ENDPOINT);
       settings.setEventBatchSize(16000);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ByteBufferWithMixedEventsIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ByteBufferWithMixedEventsIT.java
@@ -1,12 +1,7 @@
 package com.splunk.cloudfwd.test.integration;
 
 import com.splunk.cloudfwd.Connection;
-import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.UnvalidatedByteBufferEvent;
-import java.nio.ByteBuffer;
-import java.util.Properties;
 import java.util.Set;
 import org.junit.Test;
 

--- a/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionAcksDisabledIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionAcksDisabledIT.java
@@ -1,12 +1,10 @@
 package com.splunk.cloudfwd.test.integration;
 
 import com.splunk.cloudfwd.LifecycleEvent;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Properties;
 
 /**
  * Created by eprokop on 10/4/17.
@@ -22,11 +20,10 @@ public class CreateConnectionAcksDisabledIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties p = super.getProps();
-        p.setProperty(PropertyKeys.TOKEN, createTestToken(null, false));
-        p.setProperty(PropertyKeys.MAX_TOTAL_CHANNELS, "1");
-        return p;
+    protected void setProps(PropertiesFileHelper settings) {
+        super.setProps(settings);
+        settings.setToken(createTestToken(null, false));
+        settings.setMaxTotalChannels(1);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionAcksDisabledIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionAcksDisabledIT.java
@@ -20,8 +20,8 @@ public class CreateConnectionAcksDisabledIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
-        super.setProps(settings);
+    protected void configureProps(PropertiesFileHelper settings) {
+        super.configureProps(settings);
         settings.setToken(createTestToken(null, false));
         settings.setMaxTotalChannels(1);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionInvalidTokenIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionInvalidTokenIT.java
@@ -18,8 +18,8 @@ public class CreateConnectionInvalidTokenIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
-        super.setProps(settings);
+    protected void configureProps(PropertiesFileHelper settings) {
+        super.configureProps(settings);
         settings.setToken("invalid_token");
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionInvalidTokenIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionInvalidTokenIT.java
@@ -1,13 +1,10 @@
 package com.splunk.cloudfwd.test.integration;
 
-import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.LifecycleEvent;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Properties;
 
 /**
  * Created by eprokop on 10/5/17.
@@ -21,10 +18,9 @@ public class CreateConnectionInvalidTokenIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties p = super.getProps();
-        p.put(PropertyKeys.TOKEN, "invalid_token");
-        return p;
+    protected void setProps(PropertiesFileHelper settings) {
+        super.setProps(settings);
+        settings.setToken("invalid_token");
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionSomeUnknownHostsIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionSomeUnknownHostsIT.java
@@ -30,8 +30,8 @@ public class CreateConnectionSomeUnknownHostsIT extends AbstractReconciliationTe
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
-        super.setProps(settings);
+    protected void configureProps(PropertiesFileHelper settings) {
+        super.configureProps(settings);
         settings.setToken(createTestToken("__singleline"));
         settings.setUrls(unknownHost + ",https://localhost:8088");
         settings.setMaxTotalChannels(2);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionSomeUnknownHostsIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionSomeUnknownHostsIT.java
@@ -1,12 +1,10 @@
 package com.splunk.cloudfwd.test.integration;
 
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
-
-import java.util.Properties;
 import java.util.Set;
 
 import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CONFIGURATION_EXCEPTION;
@@ -32,12 +30,11 @@ public class CreateConnectionSomeUnknownHostsIT extends AbstractReconciliationTe
     }
 
     @Override
-    protected Properties getProps() {
-        Properties p = super.getProps();
-        p.setProperty(PropertyKeys.TOKEN, createTestToken("__singleline"));
-        p.setProperty(PropertyKeys.COLLECTOR_URI, unknownHost + ",https://localhost:8088");
-        p.setProperty(PropertyKeys.MAX_TOTAL_CHANNELS, "2");
-        return p;
+    protected void setProps(PropertiesFileHelper settings) {
+        super.setProps(settings);
+        settings.setToken(createTestToken("__singleline"));
+        settings.setUrls(unknownHost + ",https://localhost:8088");
+        settings.setMaxTotalChannels(2);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/integration/OnlyOnePreflightPassesIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/OnlyOnePreflightPassesIT.java
@@ -31,7 +31,7 @@ public class OnlyOnePreflightPassesIT extends AbstractReconciliationTest {
     }
     
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setToken(createTestToken(null));
         settings.setUrls("https://127.0.0.1:8088,https://kinesis4.splunkcloud.com:8088");  //two endpoints. The kinesis4 endpoint exsits, but isn't HEC endpoint (it's search head)
         settings.setMockHttp(false);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/OnlyOnePreflightPassesIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/OnlyOnePreflightPassesIT.java
@@ -2,6 +2,7 @@ package com.splunk.cloudfwd.test.integration;
 
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.PropertyKeys;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,14 +31,12 @@ public class OnlyOnePreflightPassesIT extends AbstractReconciliationTest {
     }
     
     @Override
-    protected Properties getProps() {
-        Properties p = super.getProps();
-        p.put(PropertyKeys.TOKEN, createTestToken(null));
-        p.setProperty(PropertyKeys.COLLECTOR_URI, "https://127.0.0.1:8088,https://kinesis4.splunkcloud.com:8088");  //two endpoints. The kinesis4 endpoint exsits, but isn't HEC endpoint (it's search head)
-        p.setProperty(PropertyKeys.MOCK_HTTP_KEY, "false");
-        p.setProperty(PropertyKeys.RETRIES, "3");
-        p.setProperty(PropertyKeys.MAX_TOTAL_CHANNELS, "2");
-        p.setProperty(PropertyKeys.PREFLIGHT_TIMEOUT_MS, "500000000");
-        return p;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setToken(createTestToken(null));
+        settings.setUrls("https://127.0.0.1:8088,https://kinesis4.splunkcloud.com:8088");  //two endpoints. The kinesis4 endpoint exsits, but isn't HEC endpoint (it's search head)
+        settings.setMockHttp(false);
+        settings.setMaxRetries(3);
+        settings.setMaxTotalChannels(2);
+        settings.setPreFlightTimeoutMS(500000000);
     }
 }

--- a/src/test/java/com/splunk/cloudfwd/test/integration/PeriodicEventBatchFlushIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/PeriodicEventBatchFlushIT.java
@@ -40,6 +40,7 @@ public class PeriodicEventBatchFlushIT extends AbstractReconciliationTest {
 
     @Override
     protected void configureProps(PropertiesFileHelper settings) {
+        super.configureProps(settings);
         settings.setEventBatchFlushTimeout(2000);
         settings.setEventBatchSize(100000000); // big enough that we don't fill the batch
         settings.setToken(createTestToken(SINGLE_LINE_SOURCETYPE));

--- a/src/test/java/com/splunk/cloudfwd/test/integration/PreflightTimeoutIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/PreflightTimeoutIT.java
@@ -5,6 +5,7 @@ import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CHANNEL_PREFLIGHT_TIMEOUT;
 import com.splunk.cloudfwd.error.HecNoValidChannelsException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Test;
@@ -22,14 +23,12 @@ public class PreflightTimeoutIT extends AbstractConnectionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties p = super.getProps();
-        p.setProperty(PropertyKeys.COLLECTOR_URI, "https://kinesis4.splunkcloud.com:8088"); // URL with HEC not enabled 
-        p.setProperty(PropertyKeys.MOCK_HTTP_KEY, "false");
-        p.setProperty(PropertyKeys.RETRIES, "3");
-        p.setProperty(PropertyKeys.MAX_TOTAL_CHANNELS, "4");
-        p.setProperty(PropertyKeys.PREFLIGHT_TIMEOUT_MS, "5000");
-        return p;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setUrls("https://kinesis4.splunkcloud.com:8088"); // URL with HEC not enabled
+        settings.setMockHttp(false);
+        settings.setMaxRetries(3);
+        settings.setMaxTotalChannels(4);
+        settings.setPreFlightTimeoutMS(5000);
     }
     
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/integration/PreflightTimeoutIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/PreflightTimeoutIT.java
@@ -23,7 +23,7 @@ public class PreflightTimeoutIT extends AbstractConnectionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setUrls("https://kinesis4.splunkcloud.com:8088"); // URL with HEC not enabled
         settings.setMockHttp(false);
         settings.setMaxRetries(3);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ReconciliationNoSourcetypeIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ReconciliationNoSourcetypeIT.java
@@ -17,10 +17,7 @@ package com.splunk.cloudfwd.test.integration;
 
 import com.splunk.cloudfwd.Connection;
 import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import static com.splunk.cloudfwd.test.integration.AbstractReconciliationTest.LOG;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import org.junit.Test;

--- a/src/test/java/com/splunk/cloudfwd/test/integration/SplunkEventFieldsIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/SplunkEventFieldsIT.java
@@ -17,8 +17,8 @@ public class SplunkEventFieldsIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
-        super.setProps(settings);
+    protected void configureProps(PropertiesFileHelper settings) {
+        super.configureProps(settings);
         settings.setToken(createTestToken(null));
         settings.setMaxTotalChannels(1);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/integration/SplunkEventFieldsIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/SplunkEventFieldsIT.java
@@ -1,18 +1,15 @@
 package com.splunk.cloudfwd.test.integration;
 
-import com.splunk.cloudfwd.Connection;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
 public class SplunkEventFieldsIT extends AbstractReconciliationTest {
-    
 
     @Override
     protected int getNumEventsToSend() {
@@ -20,11 +17,10 @@ public class SplunkEventFieldsIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties p = super.getProps();
-        p.setProperty(PropertyKeys.TOKEN, createTestToken(null));
-        p.setProperty(PropertyKeys.MAX_TOTAL_CHANNELS, "1");
-        return p;
+    protected void setProps(PropertiesFileHelper settings) {
+        super.setProps(settings);
+        settings.setToken(createTestToken(null));
+        settings.setMaxTotalChannels(1);
     }
 
     @Override
@@ -92,7 +88,7 @@ public class SplunkEventFieldsIT extends AbstractReconciliationTest {
         connection.getSettings().setIndex(INDEX_NAME);
         connection.getSettings().setHost(getLocalHost());
         connection.getSettings().setSource(getSource());
-         connection.getSettings().setSourcetype(getSourceType());
+        connection.getSettings().setSourcetype(getSourceType());
         super.sendEvents();
         LOG.warn("SEARCH STRING: " + getSearchString());
         Set<String> results = getEventsFromSplunk();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ToggleTokenValidityIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ToggleTokenValidityIT.java
@@ -114,7 +114,7 @@ public class ToggleTokenValidityIT extends AbstractReconciliationTest {
         }
     }
 
-    private void restoreToken() {
+    private void restoreToken() throws InterruptedException {
         LOG.info("Restoring token on server...");
         // normally if this fails it will causes the test to fail via an assert,
         // but it won't in this case since it's not being called in the main thread so we need to check
@@ -123,7 +123,8 @@ public class ToggleTokenValidityIT extends AbstractReconciliationTest {
         }
         connection.getSettings().setToken(createTestToken("__singleline"));
         LOG.info("Connection object updated with new token.");
-       
+        
+        Thread.sleep(4000); //wait for channel healths to refresh
         tokenRestoredLatch.countDown();
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ToggleTokenValidityIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ToggleTokenValidityIT.java
@@ -118,10 +118,12 @@ public class ToggleTokenValidityIT extends AbstractReconciliationTest {
         LOG.info("Restoring token on server...");
         // normally if this fails it will causes the test to fail via an assert,
         // but it won't in this case since it's not being called in the main thread so we need to check
+        connection.getSettings().setToken(createTestToken("__singleline"));
+
         if (getTokenValue() == null) {
             this.assertionFailure = "Failed to create token.";
         }
-        connection.getSettings().setToken(createTestToken("__singleline"));
+        
         LOG.info("Connection object updated with new token.");
         
         Thread.sleep(4000); //wait for channel healths to refresh

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ToggleTokenValidityIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ToggleTokenValidityIT.java
@@ -95,8 +95,8 @@ public class ToggleTokenValidityIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
-        super.setProps(settings);
+    protected void configureProps(PropertiesFileHelper settings) {
+        super.configureProps(settings);
         settings.setToken(createTestToken("__singleline"));
         // we don't want to hit any ack timeouts because it's easier to make our callbacks not expect them
         settings.setAckTimeoutMS(sendExceptionTimeout + PropertyKeys.DEFAULT_ACK_TIMEOUT_MS);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ToggleTokenValidityIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ToggleTokenValidityIT.java
@@ -3,16 +3,14 @@ package com.splunk.cloudfwd.test.integration;
 import com.splunk.cloudfwd.*;
 import com.splunk.cloudfwd.error.HecNoValidChannelsException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
-import com.splunk.cloudfwd.impl.http.httpascync.HttpCallbacksAckPoll;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 
-import java.net.UnknownHostException;
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -97,14 +95,12 @@ public class ToggleTokenValidityIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties p = super.getProps();
-        p.setProperty(PropertyKeys.TOKEN, createTestToken("__singleline"));
+    protected void setProps(PropertiesFileHelper settings) {
+        super.setProps(settings);
+        settings.setToken(createTestToken("__singleline"));
         // we don't want to hit any ack timeouts because it's easier to make our callbacks not expect them
-        p.setProperty(PropertyKeys.ACK_TIMEOUT_MS, Long.toString(sendExceptionTimeout)
-            + PropertyKeys.DEFAULT_ACK_TIMEOUT_MS);
-        p.setProperty(PropertyKeys.EVENT_BATCH_SIZE, "0"); //batching MUST be disabled for this test. If not, they way that we send some events "outside" the test framework (not using sendEvents) causes acknowledged not to countdown the latch
-        return p;
+        settings.setAckTimeoutMS(sendExceptionTimeout + PropertyKeys.DEFAULT_ACK_TIMEOUT_MS);
+        settings.setEventBatchSize(0);  //batching MUST be disabled for this test. If not, they way that we send some events "outside" the test framework (not using sendEvents) causes acknowledged not to countdown the latch
     }
 
     private void deleteTokenOnServer() {
@@ -118,24 +114,16 @@ public class ToggleTokenValidityIT extends AbstractReconciliationTest {
         }
     }
 
-    private void restoreToken() throws InterruptedException {
-        Properties p = new Properties();
+    private void restoreToken() {
         LOG.info("Restoring token on server...");
-        p.put(PropertyKeys.TOKEN, createTestToken("__singleline"));
-        LOG.info("Token restored.");
         // normally if this fails it will causes the test to fail via an assert,
         // but it won't in this case since it's not being called in the main thread so we need to check
         if (getTokenValue() == null) {
             this.assertionFailure = "Failed to create token.";
         }
-        try {
-            connection.getSettings().setProperties(p);
-            LOG.info("Connection object updated with new token.");
-        } catch (UnknownHostException e) {
-            LOG.error("TEST FAILED DUE TO " + e);
-            this.assertionFailure = e.getMessage(); // should never happen in this test
-        }
-        Thread.sleep(4000); //wait for channel healths to refresh
+        connection.getSettings().setToken(createTestToken("__singleline"));
+        LOG.info("Connection object updated with new token.");
+       
         tokenRestoredLatch.countDown();
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostDisabledCertValidationIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostDisabledCertValidationIT.java
@@ -44,7 +44,7 @@ public class SslCertDoesNotMatchHostDisabledCertValidationIT extends AbstractCon
   }
   
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setUrls("https://kinesis1-indexers-229328170.us-east-1.elb.amazonaws.com:443");
     settings.setToken("DB22D948-5A1D-4E73-8626-0AB3143BEE47");
     settings.disableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostDisabledCertValidationIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostDisabledCertValidationIT.java
@@ -14,17 +14,12 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
  * limitations under the License.
  */
 
-import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.error.HecNoValidChannelsException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import org.junit.Assert;
 import org.junit.Test;
 
-import javax.net.ssl.SSLPeerUnverifiedException;
-import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import static com.splunk.cloudfwd.PropertyKeys.*;
@@ -49,13 +44,11 @@ public class SslCertDoesNotMatchHostDisabledCertValidationIT extends AbstractCon
   }
   
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(COLLECTOR_URI, "https://kinesis1-indexers-229328170.us-east-1.elb.amazonaws.com:443");
-    props.put(TOKEN, "DB22D948-5A1D-4E73-8626-0AB3143BEE47");
-    props.put(DISABLE_CERT_VALIDATION, "true");
-    props.put(MOCK_HTTP_KEY, "false");
-    return props;
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setUrls("https://kinesis1-indexers-229328170.us-east-1.elb.amazonaws.com:443");
+    settings.setToken("DB22D948-5A1D-4E73-8626-0AB3143BEE47");
+    settings.disableCertValidation();
+    settings.setMockHttp(false);
   }
   
   @Override

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostIT.java
@@ -53,7 +53,7 @@ public class SslCertDoesNotMatchHostIT extends AbstractConnectionTest {
   }
   
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setUrls("https://kinesis1-indexers-229328170.us-east-1.elb.amazonaws.com:443");
     settings.setToken("DB22D948-5A1D-4E73-8626-0AB3143BEE47");
     settings.enableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostIT.java
@@ -14,22 +14,14 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
  * limitations under the License.
  */
 
-import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.error.HecNoValidChannelsException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import org.junit.Assert;
 import org.junit.Test;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
-import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-
-import static com.splunk.cloudfwd.PropertyKeys.*;
-import com.splunk.cloudfwd.error.HecConnectionStateException;
-import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CHANNEL_PREFLIGHT_TIMEOUT;
 
 /**
  * This test attempts to connect to ELB configured with a splunkcloud.com cert by 
@@ -61,13 +53,11 @@ public class SslCertDoesNotMatchHostIT extends AbstractConnectionTest {
   }
   
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(COLLECTOR_URI, "https://kinesis1-indexers-229328170.us-east-1.elb.amazonaws.com:443");
-    props.put(TOKEN, "DB22D948-5A1D-4E73-8626-0AB3143BEE47");
-    props.put(DISABLE_CERT_VALIDATION, "false");
-    props.put(MOCK_HTTP_KEY, "false");
-    return props;
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setUrls("https://kinesis1-indexers-229328170.us-east-1.elb.amazonaws.com:443");
+    settings.setToken("DB22D948-5A1D-4E73-8626-0AB3143BEE47");
+    settings.enableCertValidation();
+    settings.setMockHttp(false);
   }
   
   

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialDisabledCertValidationIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialDisabledCertValidationIT.java
@@ -14,17 +14,12 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
  * limitations under the License.
  */
 
-import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.error.HecNoValidChannelsException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import org.junit.Assert;
 import org.junit.Test;
 
-import javax.net.ssl.SSLHandshakeException;
-import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import static com.splunk.cloudfwd.PropertyKeys.*;
@@ -47,14 +42,12 @@ public class SslCertValidCloudTrialDisabledCertValidationIT extends AbstractConn
   }
   
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(COLLECTOR_URI, "https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
-    props.put(TOKEN, "19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
-    props.put(DISABLE_CERT_VALIDATION, "true");
-    props.put(MOCK_HTTP_KEY, "false");
-    props.put(CLOUD_SSL_CERT_CONTENT, "");
-    return props;
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setUrls("https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
+    settings.setToken("19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
+    settings.disableCertValidation();
+    settings.setMockHttp(false);
+    settings.setSSLCertContent("");
   }
   
   @Override

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialDisabledCertValidationIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialDisabledCertValidationIT.java
@@ -42,7 +42,7 @@ public class SslCertValidCloudTrialDisabledCertValidationIT extends AbstractConn
   }
   
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setUrls("https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
     settings.setToken("19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
     settings.disableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialFailByDefaultIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialFailByDefaultIT.java
@@ -17,6 +17,7 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
 import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecNoValidChannelsException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Assert;
@@ -56,14 +57,12 @@ public class SslCertValidCloudTrialFailByDefaultIT extends AbstractConnectionTes
   }
   
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(COLLECTOR_URI, "https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
-    props.put(TOKEN, "19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
-    props.put(DISABLE_CERT_VALIDATION, "false");
-    props.put(MOCK_HTTP_KEY, "false");
-    props.put(CLOUD_SSL_CERT_CONTENT, "");
-    return props;
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setUrls("https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
+    settings.setToken("19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
+    settings.enableCertValidation();
+    settings.setMockHttp(false);
+    settings.setSSLCertContent("");
   }
   
   @Override

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialFailByDefaultIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialFailByDefaultIT.java
@@ -57,7 +57,7 @@ public class SslCertValidCloudTrialFailByDefaultIT extends AbstractConnectionTes
   }
   
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setUrls("https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
     settings.setToken("19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
     settings.enableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialIT.java
@@ -16,13 +16,13 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
 
 import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import static com.splunk.cloudfwd.PropertyKeys.*;
+
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.Properties;
 
 /**
  * This test enables SSL Verification and attempts to instantiate connection
@@ -48,13 +48,11 @@ public class SslCertValidCloudTrialIT extends AbstractConnectionTest {
   }
   
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(COLLECTOR_URI, "https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
-    props.put(TOKEN, "19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
-    props.put(DISABLE_CERT_VALIDATION, "false");
-    props.put(MOCK_HTTP_KEY, "false");
-    return props;
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setUrls("https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
+    settings.setToken("19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
+    settings.enableCertValidation();
+    settings.setMockHttp(false);
   }
   
   @Override

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialIT.java
@@ -48,7 +48,7 @@ public class SslCertValidCloudTrialIT extends AbstractConnectionTest {
   }
   
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setUrls("https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
     settings.setToken("19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
     settings.enableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidIT.java
@@ -16,9 +16,8 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
 
 import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import static com.splunk.cloudfwd.PropertyKeys.*;
 
-import com.splunk.cloudfwd.impl.util.HecChannel;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -53,22 +52,20 @@ public class SslCertValidIT extends AbstractConnectionTest {
   }
   
   @Override
-  protected Properties getTestProps() {
-    return new Properties();
+  protected PropertiesFileHelper getTestProps() {
+    return new PropertiesFileHelper();
   }
   
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(COLLECTOR_URI, "https://http-inputs-kinesis1.splunkcloud.com:443");
-    props.put(TOKEN, "DB22D948-5A1D-4E73-8626-0AB3143BEE47");
-    props.put(DISABLE_CERT_VALIDATION, "false");
-    props.put(MOCK_HTTP_KEY, "false");
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setUrls("https://http-inputs-kinesis1.splunkcloud.com:443");
+    settings.setToken("DB22D948-5A1D-4E73-8626-0AB3143BEE47");
+    settings.enableCertValidation();
+    settings.setMockHttp(false);
     // Despite we overwrite getTestProps here, ConnectionSettings will read
     // cloudfwd.properties file anyway. So we set CLOUD_SSL_CERT_CONTENT to
     // empty string explicitly.
-    props.put(CLOUD_SSL_CERT_CONTENT, "");
-    return props;
+    settings.setSSLCertContent("");
   }
 
   @Override

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidIT.java
@@ -53,7 +53,7 @@ public class SslCertValidIT extends AbstractConnectionTest {
   
   @Override
   protected PropertiesFileHelper getTestProps() {
-    return new PropertiesFileHelper();
+    return new PropertiesFileHelper();  
   }
   
   @Override
@@ -65,6 +65,7 @@ public class SslCertValidIT extends AbstractConnectionTest {
     // Despite we overwrite getTestProps here, ConnectionSettings will read
     // cloudfwd.properties file anyway. So we set CLOUD_SSL_CERT_CONTENT to
     // empty string explicitly.
+    //FIXME: This call below should set this.cloudSslCertContent, not this.sslCertContent (fails isCloudInstance()) call
     settings.setSSLCertContent("");
   }
 

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidIT.java
@@ -57,7 +57,7 @@ public class SslCertValidIT extends AbstractConnectionTest {
   }
   
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setUrls("https://http-inputs-kinesis1.splunkcloud.com:443");
     settings.setToken("DB22D948-5A1D-4E73-8626-0AB3143BEE47");
     settings.enableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/mock/AbstractMutabilityTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/AbstractMutabilityTest.java
@@ -24,7 +24,7 @@ public abstract class AbstractMutabilityTest extends AbstractConnectionTest {
     }
 
     @Override
-    abstract protected void setProps(PropertiesFileHelper settings);
+    abstract protected void configureProps(PropertiesFileHelper settings);
 
     protected void sendSomeEvents(int numEvents) throws InterruptedException, HecConnectionTimeoutException {
         LOG.trace(

--- a/src/test/java/com/splunk/cloudfwd/test/mock/AbstractMutabilityTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/AbstractMutabilityTest.java
@@ -4,9 +4,9 @@ import com.splunk.cloudfwd.Connection;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -24,7 +24,7 @@ public abstract class AbstractMutabilityTest extends AbstractConnectionTest {
     }
 
     @Override
-    abstract protected Properties getProps();
+    abstract protected void setProps(PropertiesFileHelper settings);
 
     protected void sendSomeEvents(int numEvents) throws InterruptedException, HecConnectionTimeoutException {
         LOG.trace(

--- a/src/test/java/com/splunk/cloudfwd/test/mock/AcknowledgementTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/AcknowledgementTimeoutTest.java
@@ -18,12 +18,10 @@ import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.EventBatch;
 import com.splunk.cloudfwd.error.HecAcknowledgmentTimeoutException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import static com.splunk.cloudfwd.PropertyKeys.*;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints;
-import java.util.Properties;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -40,8 +38,7 @@ public class AcknowledgementTimeoutTest extends AbstractConnectionTest {
     private static final Logger LOG = LoggerFactory.getLogger(
             AcknowledgementTimeoutTest.class.getName());
 
-    public AcknowledgementTimeoutTest() {
-    }
+    public AcknowledgementTimeoutTest() {}
 
     @Override
     @Before
@@ -49,12 +46,12 @@ public class AcknowledgementTimeoutTest extends AbstractConnectionTest {
         super.setUp();
     }
     
-  @After
-  @Override
-  public void tearDown() {
+    @After
+    @Override
+    public void tearDown() {
         super.tearDown();
         connection.closeNow();
-  }    
+    }    
 
     @Test
     public void testTimeout() throws InterruptedException, HecConnectionTimeoutException {
@@ -63,23 +60,17 @@ public class AcknowledgementTimeoutTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
+    protected void setProps(PropertiesFileHelper settings) {
         // props.put(PropertiesFileHelper.MOCK_HTTP_KEY, "true");
         //simulate a slow endpoint
-        props.put(MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
-
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
         if (SlowEndpoints.sleep > 10000) {
             throw new RuntimeException("Let's not get carried away here");
         }
-
-        props.put(ACK_TIMEOUT_MS, Long.toString(1000));
-        props.put(UNRESPONSIVE_MS,
-                "-1");//disable dead channel detection
-        props.put(PropertyKeys.EVENT_BATCH_SIZE, 0);
+        settings.setAckTimeoutMS(1000);
+        settings.setUnresponsiveMS(-1); //disable dead channel detection
+        settings.setEventBatchSize(0);
         //props.put(PropertyKeys.MAX_TOTAL_CHANNELS, 1);
-        return props;
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/AcknowledgementTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/AcknowledgementTimeoutTest.java
@@ -60,7 +60,7 @@ public class AcknowledgementTimeoutTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         // props.put(PropertiesFileHelper.MOCK_HTTP_KEY, "true");
         //simulate a slow endpoint
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");

--- a/src/test/java/com/splunk/cloudfwd/test/mock/BatchedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/BatchedVolumeTest.java
@@ -34,7 +34,7 @@ public class BatchedVolumeTest extends AbstractConnectionTest {
   }
   
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
       settings.setAckTimeoutMS(1000000);
       settings.setUnresponsiveMS(-1); //no dead channel detection
   }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/BatchedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/BatchedVolumeTest.java
@@ -17,9 +17,8 @@ package com.splunk.cloudfwd.test.mock;/*
 import com.splunk.cloudfwd.Connection;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import java.util.concurrent.TimeoutException;
 
@@ -35,11 +34,9 @@ public class BatchedVolumeTest extends AbstractConnectionTest {
   }
   
     @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(PropertyKeys.ACK_TIMEOUT_MS, "1000000"); //we don't want the ack timout kicking in
-    props.put(PropertyKeys.UNRESPONSIVE_MS, "-1"); //no dead channel detection
-    return props;
+    protected void setProps(PropertiesFileHelper settings) {
+      settings.setAckTimeoutMS(1000000);
+      settings.setUnresponsiveMS(-1); //no dead channel detection
   }
 
   @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ByteBufferEventTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ByteBufferEventTest.java
@@ -42,7 +42,7 @@ public class ByteBufferEventTest extends AbstractConnectionTest {
   }
 
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     //default behavior is no "hard coded" test-specific properties
     settings.setEventBatchSize(16000);
     settings.setMockHttp(true); //no dead channel detection

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ByteBufferEventTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ByteBufferEventTest.java
@@ -3,11 +3,10 @@ package com.splunk.cloudfwd.test.mock;
 import com.splunk.cloudfwd.Connection;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.UnvalidatedByteBufferEvent;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.nio.ByteBuffer;
-import java.util.Properties;
 import org.junit.Test;
 
 /*
@@ -41,15 +40,14 @@ public class ByteBufferEventTest extends AbstractConnectionTest {
   protected int getNumEventsToSend() {
     return 100;
   }
-  
+
   @Override
-    protected Properties getProps() {
-    Properties props = new Properties(); //default behavior is no "hard coded" test-specific properties
-    props.put(PropertyKeys.EVENT_BATCH_SIZE,  "16000");
-    props.put(PropertyKeys.MOCK_HTTP_KEY, "true");
+  protected void setProps(PropertiesFileHelper settings) {
+    //default behavior is no "hard coded" test-specific properties
+    settings.setEventBatchSize(16000);
+    settings.setMockHttp(true); //no dead channel detection
     super.eventType = Event.Type.UNKNOWN;
-    return props;
-  }  
+  }
   
   @Override
   protected Event nextEvent(int seqno) {

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ChangeEndpointWhileAccumulatingBatch.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ChangeEndpointWhileAccumulatingBatch.java
@@ -33,7 +33,7 @@ import org.junit.Test;
  */
 public class ChangeEndpointWhileAccumulatingBatch extends AbstractConnectionTest{
 
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setEventBatchSize(1024*1024);
   }
     

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ChangeEndpointWhileAccumulatingBatch.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ChangeEndpointWhileAccumulatingBatch.java
@@ -19,6 +19,8 @@ import com.splunk.cloudfwd.Connection;
 import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.WRONG_EVENT_FORMAT_FOR_ENDPOINT;
+
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import java.util.Properties;
 import org.junit.Test;
@@ -30,11 +32,9 @@ import org.junit.Test;
  * @author ghendrey
  */
 public class ChangeEndpointWhileAccumulatingBatch extends AbstractConnectionTest{
-    
-  protected Properties getProps() {
-    Properties p = new Properties(); 
-    p.setProperty(PropertyKeys.DEFAULT_EVENT_BATCH_SIZE,String.valueOf(1024*1024));
-    return p;
+
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setEventBatchSize(1024*1024);
   }
     
     @Test

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CloseNowTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CloseNowTest.java
@@ -2,6 +2,7 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Test;
@@ -17,11 +18,9 @@ public class CloseNowTest extends AbstractConnectionTest {
         super.sendEvents(true, true);
     }
     
-    @Override 
-    protected Properties getProps() {
-        Properties p = super.getProps();
-        p.setProperty(PropertyKeys.MOCK_HTTP_KEY, "true");
-        return p;
+    @Override
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttp(true);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CloseNowTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CloseNowTest.java
@@ -19,7 +19,7 @@ public class CloseNowTest extends AbstractConnectionTest {
     }
     
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttp(true);
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionMutabilityTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionMutabilityTest.java
@@ -1,17 +1,17 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.impl.ConnectionImpl;
 import com.splunk.cloudfwd.impl.sim.ValidatePropsEndpoint;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.UnknownHostException;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -23,48 +23,6 @@ public class ConnectionMutabilityTest extends AbstractConnectionTest {
     private int stop = -1;
     private long ackPollWait = 1000;
 
-    
-    @Test
-    // Makes sure we are computing diffs as expected
-    public void testPropertiesDiffs() throws UnknownHostException {
-        LOG.info("test:  testPropertiesDiffs");
-        Properties props1 = new Properties();
-        props1.setProperty(PropertyKeys.TOKEN, "a token");
-        props1.setProperty(PropertyKeys.ACK_TIMEOUT_MS, "30000");
-        props1.setProperty(PropertyKeys.COLLECTOR_URI, "https://127.0.0.1:8088");
-        LOG.info("setProperties(props1)");
-        connection.getSettings().setProperties(props1);
-
-        // Diff for the same properties
-        Properties props2 = new Properties();
-        props2.setProperty(PropertyKeys.COLLECTOR_URI, "https://127.0.0.1:8088");
-        props2.setProperty(PropertyKeys.ACK_TIMEOUT_MS, "30000");
-        props2.setProperty(PropertyKeys.TOKEN, "a token");
-        Properties diff = connection.getSettings().getDiff(props2);
-        Assert.assertTrue("Diff should be empty.", diff.isEmpty());
-
-        // Diff for some different properties
-        Properties props3 = new Properties();
-        String diffToken = "a different token";
-        String diffUrl = "https://127.0.0.1:8188, https://127.0.0.1:8288, https://127.0.0.1:8388";
-        String diffChannelDecom = "50000";
-        props3.setProperty(PropertyKeys.ACK_TIMEOUT_MS, "30000"); // same as before
-        props3.setProperty(PropertyKeys.TOKEN, diffToken);
-        props3.setProperty(PropertyKeys.COLLECTOR_URI, diffUrl);
-        props3.setProperty(PropertyKeys.CHANNEL_DECOM_MS, diffChannelDecom);
-        LOG.info("setProperties(props3)");
-        diff = connection.getSettings().getDiff(props3);
-        Assert.assertTrue("Diff should contain token.", diff.getProperty(PropertyKeys.TOKEN).equals(diffToken));
-        Assert.assertTrue("Diff should contain urls.", diff.getProperty(PropertyKeys.COLLECTOR_URI).equals(diffUrl));
-        Assert.assertTrue("Diff should contain channel decom time.", diff.getProperty(PropertyKeys.CHANNEL_DECOM_MS).equals(diffChannelDecom));
-        Assert.assertTrue("Diff should contain exactly 3 elements.", diff.size() == 3);
-
-        // Diff for empty Properties
-        diff = connection.getSettings().getDiff(new Properties());
-        Assert.assertTrue("Diff for empty properties should be empty.", diff.isEmpty());
-    }
-
-
     @Test
     public void setMultipleProperties() throws Throwable {
         LOG.info("test:  setMultipleProperties");       
@@ -75,29 +33,28 @@ public class ConnectionMutabilityTest extends AbstractConnectionTest {
         sendSomeEvents(getNumEventsToSend()/4);
 
         // Set some new properties
-        Properties props1 = new Properties();
-        props1.setProperty(PropertyKeys.TOKEN, "a token");
-        props1.setProperty(PropertyKeys.ACK_TIMEOUT_MS, "120000");
-        props1.setProperty(PropertyKeys.COLLECTOR_URI, "https://127.0.0.1:8188");
-        connection.getSettings().setProperties(props1);
+        ConnectionSettings settings = connection.getSettings();
+        settings.setToken("a token");
+        settings.setAckTimeoutMS(120000);
+        settings.setUrls("https://127.0.0.1:8188");
         setPropsOnEndpoint();
         LOG.info("sending second batch of events");
         sendSomeEvents(getNumEventsToSend()/4);
 
 
         // Set the same properties
-        connection.getSettings().setProperties(props1);
+        settings.setToken("a token");
+        settings.setAckTimeoutMS(120000);
+        settings.setUrls("https://127.0.0.1:8188");
         setPropsOnEndpoint();
         LOG.info("sending third batch of events");
         sendSomeEvents(getNumEventsToSend()/4);
 
 
         // Set some more new properties
-        Properties props2 = new Properties();
-        props2.setProperty(PropertyKeys.TOKEN, "different token");
-        props2.setProperty(PropertyKeys.ACK_TIMEOUT_MS, "240000");
-        props2.setProperty(PropertyKeys.COLLECTOR_URI, "https://127.0.0.1:8288, https://127.0.0.1:8388");
-        connection.getSettings().setProperties(props2);
+        settings.setToken("different token");
+        settings.setAckTimeoutMS(240000);
+        settings.setUrls("https://127.0.0.1:8288, https://127.0.0.1:8388");
         setPropsOnEndpoint();
          LOG.info("sending fourth batch of events");
         sendSomeEvents(getNumEventsToSend()/4);
@@ -176,14 +133,12 @@ public class ConnectionMutabilityTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(PropertyKeys.ACK_TIMEOUT_MS, "1000000"); //we don't want the ack timout kicking in
-        props.put(PropertyKeys.UNRESPONSIVE_MS, "-1"); //no dead channel detection
-        props.put(PropertyKeys.MOCK_HTTP_KEY, "true");
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setAckTimeoutMS(1000000);
+        settings.setUnresponsiveMS(-1); //no dead channel detection
+        settings.setMockHttp(true);
         // the asserts for this test exist in the endpoint since we must check values server side
-        props.put(PropertyKeys.MOCK_HTTP_CLASSNAME, "com.splunk.cloudfwd.impl.sim.ValidatePropsEndpoint");
-        return props;
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.ValidatePropsEndpoint");
     }
 
     private void setPropsOnEndpoint() {

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionMutabilityTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionMutabilityTest.java
@@ -133,7 +133,7 @@ public class ConnectionMutabilityTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setAckTimeoutMS(1000000);
         settings.setUnresponsiveMS(-1); //no dead channel detection
         settings.setMockHttp(true);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionTimeoutTest.java
@@ -2,9 +2,8 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,21 +34,18 @@ public class ConnectionTimeoutTest extends AbstractConnectionTest {
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionTimeoutTest.class.getName());
 
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
+  protected void setProps(PropertiesFileHelper settings) {
     //A realistic value of BLOCKING_TIMEOUT_MS would be 1 or more MINUTES, but let's not
     //make this test run too slowly. The point is, we want to SEE the HecConnectionTimeout
     //happen repeatedly, until the message goes through
-    props.put(PropertyKeys.BLOCKING_TIMEOUT_MS, "100"); //block for 100 ms before HecConnectionTimeout
+    settings.setBlockingTimeoutMS(100);//block for 100 ms before HecConnectionTimeout
     //install an endpoint that takes 10 seconds to return an ack
-    props.put(PropertyKeys.MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
-    props.put(PropertyKeys.MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL, "1"); //firs batch will send, second will block
-    props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "1");
-    props.put(PropertyKeys.ACK_TIMEOUT_MS, "60000"); //we don't want the ack timout kicking in
-    props.put(PropertyKeys.ACK_POLL_MS, "250");
-    props.put(PropertyKeys.UNRESPONSIVE_MS, "-1"); //no dead channel detection
-    return props;
+    settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
+    settings.setMaxUnackedEventBatchPerChannel(1);
+    settings.setMaxTotalChannels(1);
+    settings.setAckTimeoutMS(60000);
+    settings.setAckPollMS(250);
+    settings.setUnresponsiveMS(-1);
   }
 
   @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionTimeoutTest.java
@@ -34,7 +34,7 @@ public class ConnectionTimeoutTest extends AbstractConnectionTest {
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionTimeoutTest.class.getName());
 
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     //A realistic value of BLOCKING_TIMEOUT_MS would be 1 or more MINUTES, but let's not
     //make this test run too slowly. The point is, we want to SEE the HecConnectionTimeout
     //happen repeatedly, until the message goes through

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionNoRouteToHost.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionNoRouteToHost.java
@@ -22,7 +22,7 @@ public class CreateConnectionNoRouteToHost extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttp(true);
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.NoRouteToHostEndpoints");
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionNoRouteToHost.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionNoRouteToHost.java
@@ -4,6 +4,7 @@ import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.integration.AbstractReconciliationTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -21,11 +22,9 @@ public class CreateConnectionNoRouteToHost extends AbstractReconciliationTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties p = super.getProps();
-        p.put(PropertyKeys.MOCK_HTTP_KEY, "true");
-        p.put(PropertyKeys.MOCK_HTTP_CLASSNAME, "com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.NoRouteToHostEndpoints");
-        return p;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttp(true);
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.NoRouteToHostEndpoints");
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionUnknownHostTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionUnknownHostTest.java
@@ -1,12 +1,9 @@
 package com.splunk.cloudfwd.test.mock;
 
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
-
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 
 import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CONFIGURATION_EXCEPTION;
-import com.splunk.cloudfwd.error.HecMaxRetriesException;
 
 /**
  * Scenario: Unknown host provided (no "good" URLs)
@@ -16,16 +13,15 @@ import com.splunk.cloudfwd.error.HecMaxRetriesException;
  */
 public class CreateConnectionUnknownHostTest extends ExceptionConnInstantiationTest {
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(PropertyKeys.COLLECTOR_URI, "https://foobarunknownhostbaz:8088");
-        props.put(PropertyKeys.MOCK_HTTP_CLASSNAME, "com.splunk.cloudfwd.impl.sim.errorgen.unknownhost.UnknownHostEndpoints");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setUrls("https://foobarunknownhostbaz:8088");
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unknownhost.UnknownHostEndpoints");
     }
 
     protected boolean isExpectedConnInstantiationException(Exception e) {
-        if (e instanceof HecMaxRetriesException) {
-            return  e.getMessage().equals("Simulated UnknownHostException");
+        if (e instanceof HecConnectionStateException) {
+            return ((HecConnectionStateException)e).getType() == CONFIGURATION_EXCEPTION
+                && e.getMessage().equals("Could not resolve any host names.");
         }
         return false;
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionUnknownHostTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionUnknownHostTest.java
@@ -1,9 +1,7 @@
 package com.splunk.cloudfwd.test.mock;
 
-import com.splunk.cloudfwd.error.HecConnectionStateException;
+import com.splunk.cloudfwd.error.HecMaxRetriesException;
 import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
-
-import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CONFIGURATION_EXCEPTION;
 
 /**
  * Scenario: Unknown host provided (no "good" URLs)
@@ -19,10 +17,12 @@ public class CreateConnectionUnknownHostTest extends ExceptionConnInstantiationT
     }
 
     protected boolean isExpectedConnInstantiationException(Exception e) {
-        if (e instanceof HecConnectionStateException) {
-            return ((HecConnectionStateException)e).getType() == CONFIGURATION_EXCEPTION
-                && e.getMessage().equals("Could not resolve any host names.");
+        if (e instanceof HecMaxRetriesException) {
+            return  e.getMessage().equals("Simulated UnknownHostException");
         }
         return false;
     }
 }
+
+
+

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionUnknownHostTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionUnknownHostTest.java
@@ -11,7 +11,7 @@ import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
  */
 public class CreateConnectionUnknownHostTest extends ExceptionConnInstantiationTest {
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setUrls("https://foobarunknownhostbaz:8088");
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unknownhost.UnknownHostEndpoints");
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/DeadChannelTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/DeadChannelTest.java
@@ -2,14 +2,10 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Connection;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import static com.splunk.cloudfwd.PropertyKeys.MAX_TOTAL_CHANNELS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_KEY;
-import static com.splunk.cloudfwd.PropertyKeys.UNRESPONSIVE_MS;
 import com.splunk.cloudfwd.error.HecChannelDeathException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeoutException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -50,16 +46,11 @@ public class DeadChannelTest extends AbstractConnectionTest {
     }
 
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.setProperty(MOCK_HTTP_KEY, "true");
-    props.setProperty(MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.ackslost.LossyEndpoints");
-    props.setProperty(UNRESPONSIVE_MS,
-            "4000"); //set dead channel detector to detect at 1 second    
-        props.setProperty(MAX_TOTAL_CHANNELS,
-            "2");
-    return props;
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setMockHttp(true);
+    settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.ackslost.LossyEndpoints");
+    settings.setUnresponsiveMS(4000);
+    settings.setMaxTotalChannels(2);
   }
   
   @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/DeadChannelTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/DeadChannelTest.java
@@ -46,7 +46,7 @@ public class DeadChannelTest extends AbstractConnectionTest {
     }
 
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setMockHttp(true);
     settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.ackslost.LossyEndpoints");
     settings.setUnresponsiveMS(4000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersAllDownTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersAllDownTest.java
@@ -2,17 +2,16 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.ConnectionCallbacks;
 import com.splunk.cloudfwd.Connections;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.ConnectException;
 import java.util.ArrayList;
-import java.util.Properties;
 
 /**
  * Created by mhora on 10/4/17.
@@ -30,17 +29,13 @@ public class DownIndexersAllDownTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(PropertyKeys.MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.indexer.DownIndexerEndpoints");
-        props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "4");
-        props.put(PropertyKeys.BLOCKING_TIMEOUT_MS, "10000");
-        props.put(PropertyKeys.HEALTH_POLL_MS, "1000");
-        props.put(PropertyKeys.ACK_TIMEOUT_MS, "60000");
-        props.put(PropertyKeys.UNRESPONSIVE_MS, "-1"); //no dead channel detection
-
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.DownIndexerEndpoints");
+        settings.setMaxTotalChannels(4);
+        settings.setBlockingTimeoutMS(10000);
+        settings.setHealthPollMS(1000);
+        settings.setAckTimeoutMS(60000);
+        settings.setUnresponsiveMS(-1); //no dead channel detection
     }
 
     // Need to separate this logic out of setUp() so that each Test
@@ -48,10 +43,9 @@ public class DownIndexersAllDownTest extends AbstractConnectionTest {
     private void createConnection() {
         this.callbacks = getCallbacks();
 
-        Properties props = new Properties();
-        props.putAll(getTestProps());
-        props.putAll(getProps());
-        this.connection = Connections.create((ConnectionCallbacks) callbacks, props);
+        PropertiesFileHelper settings = getTestProps();
+        setProps(settings);
+        connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersAllDownTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersAllDownTest.java
@@ -29,7 +29,7 @@ public class DownIndexersAllDownTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.DownIndexerEndpoints");
         settings.setMaxTotalChannels(4);
         settings.setBlockingTimeoutMS(10000);
@@ -44,7 +44,7 @@ public class DownIndexersAllDownTest extends AbstractConnectionTest {
         this.callbacks = getCallbacks();
 
         PropertiesFileHelper settings = getTestProps();
-        setProps(settings);
+        configureProps(settings);
         connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersRollingRestartTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersRollingRestartTest.java
@@ -25,7 +25,7 @@ public class DownIndexersRollingRestartTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.RollingRestartEndpoints");
 
         // mocking 4 indexers with 1 channel each
@@ -49,7 +49,7 @@ public class DownIndexersRollingRestartTest extends AbstractConnectionTest {
         this.callbacks = getCallbacks();
 
         PropertiesFileHelper settings = this.getTestProps();
-        this.setProps(settings);
+        this.configureProps(settings);
         this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersRollingRestartTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersRollingRestartTest.java
@@ -2,13 +2,13 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.ConnectionCallbacks;
 import com.splunk.cloudfwd.Connections;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.impl.sim.errorgen.indexer.RollingRestartEndpoints;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
+import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Properties;
 
 /**
  * Created by mhora on 10/4/17.
@@ -25,27 +25,22 @@ public class DownIndexersRollingRestartTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(PropertyKeys.MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.errorgen.indexer.RollingRestartEndpoints");
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.RollingRestartEndpoints");
 
         // mocking 4 indexers with 1 channel each
         // although no guarantee which channel goes to which indexer by LoadBalancer
         // but simulate anyway
-        props.put(PropertyKeys.COLLECTOR_URI,
-                "https://127.0.0.1:8088,https://127.0.1.1:8088,https://127.0.2.1:8088,https://127.0.3.1:8088");
-        props.put(PropertyKeys.MOCK_FORCE_URL_MAP_TO_ONE, "true");
-        props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "4");
-        props.put(PropertyKeys.MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL, "2");
+        settings.setUrls("https://127.0.0.1:8088,https://127.0.1.1:8088,https://127.0.2.1:8088,https://127.0.3.1:8088");
+        settings.setMockForceUrlMapToOne(true);
+        settings.setMaxTotalChannels(4);
+        settings.setMaxUnackedEventBatchPerChannel(2);
         RollingRestartEndpoints.init(4, 1);
 
-        props.put(PropertyKeys.BLOCKING_TIMEOUT_MS, "10000");
-        props.put(PropertyKeys.HEALTH_POLL_MS, "1000");
-        props.put(PropertyKeys.ACK_TIMEOUT_MS, "60000");
-        props.put(PropertyKeys.UNRESPONSIVE_MS, "-1"); //no dead channel detection
-
-        return props;
+        settings.setBlockingTimeoutMS(10000);
+        settings.setHealthPollMS(1000);
+        settings.setAckTimeoutMS(60000);
+        settings.setUnresponsiveMS(-1); //no dead channel detection
     }
 
     // Need to separate this logic out of setUp() so that each Test
@@ -53,10 +48,9 @@ public class DownIndexersRollingRestartTest extends AbstractConnectionTest {
     private void createConnection() {
         this.callbacks = getCallbacks();
 
-        Properties props = new Properties();
-        props.putAll(getTestProps());
-        props.putAll(getProps());
-        this.connection = Connections.create((ConnectionCallbacks) callbacks, props);
+        PropertiesFileHelper settings = this.getTestProps();
+        this.setProps(settings);
+        this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ExceptionConnInstantiationTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ExceptionConnInstantiationTest.java
@@ -1,10 +1,9 @@
 package com.splunk.cloudfwd.test.mock;
 
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.net.MalformedURLException;
-import java.util.Properties;
 import org.junit.Test;
 
 /*
@@ -35,10 +34,8 @@ public class ExceptionConnInstantiationTest extends AbstractConnectionTest{
     }
 
     @Override
-    protected Properties getProps() {
-       Properties props = new Properties();
-       props.put(PropertyKeys.COLLECTOR_URI, "floort");
-       return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setUrls("floort");
     }
     
     @Test

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ExceptionConnInstantiationTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ExceptionConnInstantiationTest.java
@@ -34,7 +34,7 @@ public class ExceptionConnInstantiationTest extends AbstractConnectionTest{
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setUrls("floort");
     }
     

--- a/src/test/java/com/splunk/cloudfwd/test/mock/GatewayTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/GatewayTimeoutTest.java
@@ -1,14 +1,12 @@
 package com.splunk.cloudfwd.test.mock;
 
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
-
-import java.util.Properties;
 
 /**
  * Created by eprokop on 9/29/17.
@@ -21,12 +19,10 @@ public class GatewayTimeoutTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties p = new Properties();
-        p.setProperty(PropertyKeys.MOCK_HTTP_CLASSNAME, "com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostGatewayTimeoutEndpoints");
-        p.setProperty(PropertyKeys.BLOCKING_TIMEOUT_MS, "5000");
-        p.setProperty(PropertyKeys.ACK_TIMEOUT_MS, "500000");
-        return p;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostGatewayTimeoutEndpoints");
+        settings.setBlockingTimeoutMS(5000);
+        settings.setAckTimeoutMS(500000);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/GatewayTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/GatewayTimeoutTest.java
@@ -19,7 +19,7 @@ public class GatewayTimeoutTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostGatewayTimeoutEndpoints");
         settings.setBlockingTimeoutMS(5000);
         settings.setAckTimeoutMS(500000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/HecEndpointEventTypeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/HecEndpointEventTypeTest.java
@@ -36,7 +36,7 @@ public class HecEndpointEventTypeTest extends AbstractConnectionTest {
 
  
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setMockHttp(true);
   }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/HecEndpointEventTypeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/HecEndpointEventTypeTest.java
@@ -16,9 +16,8 @@ package com.splunk.cloudfwd.test.mock;/*
 
 import com.splunk.cloudfwd.Connection.HecEndpoint;
 import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import java.util.*;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,10 +36,8 @@ public class HecEndpointEventTypeTest extends AbstractConnectionTest {
 
  
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(PropertyKeys.MOCK_HTTP_KEY, "true");
-    return props;
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setMockHttp(true);
   }
 
   @Test

--- a/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadyAckdTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadyAckdTest.java
@@ -2,10 +2,8 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
-import com.splunk.cloudfwd.PropertyKeys;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_KEY;
-import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -32,13 +30,11 @@ import java.util.logging.Logger;
 public class IllegalStateAlreadyAckdTest extends IllegalStateAlreadySentTest{
   
     @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(MOCK_HTTP_KEY, "true");
-    props.put(PropertyKeys.EVENT_BATCH_SIZE, "0"); //make sure no batching
-    props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "1"); //so we insure we resend on same channel   
-    props.put(PropertyKeys.ENABLE_CHECKPOINTS, "true"); //checkpoints are required for this to work      
-    return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttp(true);
+        settings.setEventBatchSize(0); //make sure no batching
+        settings.setMaxTotalChannels(1); //so we insure we resend on same channel
+        settings.setCheckpointEnabled(true); //checkpoints are required for this to work
   }
     protected HecConnectionStateException.Type getExceptionType(){
     return HecConnectionStateException.Type.ALREADY_HANDLED;

--- a/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadyAckdTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadyAckdTest.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class IllegalStateAlreadyAckdTest extends IllegalStateAlreadySentTest{
   
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttp(true);
         settings.setEventBatchSize(0); //make sure no batching
         settings.setMaxTotalChannels(1); //so we insure we resend on same channel

--- a/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadySentTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadySentTest.java
@@ -2,13 +2,10 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_KEY;
-import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,16 +33,13 @@ public class IllegalStateAlreadySentTest extends AbstractConnectionTest {
   private HecConnectionStateException.Type expectedExType;
 
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(MOCK_HTTP_KEY, "true");
-    props.put(MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
-    props.put(PropertyKeys.EVENT_BATCH_SIZE, "0"); //make sure no batching
-    props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "1"); //so we insure we resend on same channel   
-    props.put(PropertyKeys.ACK_TIMEOUT_MS, "-1");     
-    props.put(PropertyKeys.ENABLE_CHECKPOINTS, "true"); //checkpoints are required for this to work      
-    return props;
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setMockHttp(true);
+    settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
+    settings.setEventBatchSize(0);
+    settings.setMaxTotalChannels(1);
+    settings.setAckTimeoutMS(-1);
+    settings.setCheckpointEnabled(true);
   }
   
   @Before

--- a/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadySentTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadySentTest.java
@@ -33,7 +33,7 @@ public class IllegalStateAlreadySentTest extends AbstractConnectionTest {
   private HecConnectionStateException.Type expectedExType;
 
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setMockHttp(true);
     settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
     settings.setEventBatchSize(0);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/MaxRetriesTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/MaxRetriesTest.java
@@ -2,11 +2,10 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecChannelDeathException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,22 +36,19 @@ public class MaxRetriesTest extends AbstractConnectionTest {
   private static final Logger LOG = LoggerFactory.getLogger(MaxRetriesTest.class.getName());
 
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
+  protected void setProps(PropertiesFileHelper settings) {
     //A realistic value of BLOCKING_TIMEOUT_MS would be 1 or more MINUTES, but let's not
     //make this test run too slowly. The point is, we want to SEE the HecConnectionTimeout
     //happen repeatedly, until the message goes through
-    props.put(PropertyKeys.BLOCKING_TIMEOUT_MS, "100"); //block for 100 ms before HecConnectionTimeout
-    //install an endpoint that takes 10 seconds to return an ack
-    props.put(PropertyKeys.MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
-    props.put(PropertyKeys.MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL, "1");
-    props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "1");
-    props.put(PropertyKeys.ACK_TIMEOUT_MS, "60000"); //we don't want the ack timout kicking in
-    props.put(PropertyKeys.ACK_POLL_MS, "250");
-    props.put(PropertyKeys.RETRIES, "2");
-    props.put(PropertyKeys.UNRESPONSIVE_MS, "100"); //for this test, lets QUICKLY determine the channel is dead
-    return props;
+      settings.setBlockingTimeoutMS(100); //block for 100 ms before HecConnectionTimeout
+      //install an endpoint that takes 10 seconds to return an ack
+      settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
+      settings.setMaxUnackedEventBatchPerChannel(1);
+      settings.setMaxTotalChannels(1);
+      settings.setAckTimeoutMS(60000);
+      settings.setAckPollMS(250);
+      settings.setMaxRetries(2);
+      settings.setUnresponsiveMS(100);
   }
   
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/MaxRetriesTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/MaxRetriesTest.java
@@ -36,7 +36,7 @@ public class MaxRetriesTest extends AbstractConnectionTest {
   private static final Logger LOG = LoggerFactory.getLogger(MaxRetriesTest.class.getName());
 
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     //A realistic value of BLOCKING_TIMEOUT_MS would be 1 or more MINUTES, but let's not
     //make this test run too slowly. The point is, we want to SEE the HecConnectionTimeout
     //happen repeatedly, until the message goes through

--- a/src/test/java/com/splunk/cloudfwd/test/mock/NonBatchedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/NonBatchedVolumeTest.java
@@ -2,7 +2,7 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
@@ -38,10 +38,8 @@ public class NonBatchedVolumeTest extends AbstractConnectionTest {
 
 
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    //props.put(PropertiesFileHelper.MOCK_HTTP_KEY, "true");
-    return props;
+  protected void setProps(PropertiesFileHelper settings) {
+    //settings.setMockHttp(true);
   }
 
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/NonBatchedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/NonBatchedVolumeTest.java
@@ -38,7 +38,7 @@ public class NonBatchedVolumeTest extends AbstractConnectionTest {
 
 
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     //settings.setMockHttp(true);
   }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdTest.java
@@ -3,15 +3,11 @@ package com.splunk.cloudfwd.test.mock;
 import com.splunk.cloudfwd.ConnectionCallbacks;
 import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.EventBatch;
-import com.splunk.cloudfwd.PropertyKeys;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
-
 import java.util.ArrayList;
-import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,7 +28,7 @@ import org.junit.Test;
  */
 /**
  *
- * @author mescobar
+ * @author ghendrey
  */
 public class OutOfOrderAckIdTest extends AbstractConnectionTest {
 
@@ -60,18 +56,14 @@ public class OutOfOrderAckIdTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDEndpoints");
-        props.put(BLOCKING_TIMEOUT_MS, "30000");
-        props.put(PropertyKeys.UNRESPONSIVE_MS, "-1"); //no dead channel detection
-        props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "2");
-        props.put(PropertyKeys.ACK_TIMEOUT_MS, "60000"); //we don't want the ack timout kicking in
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDEndpoints");
+        settings.setBlockingTimeoutMS(30000);
+        settings.setUnresponsiveMS(-1); //no dead channel detection
+        settings.setMaxTotalChannels(2);
+        settings.setAckTimeoutMS(60000); //we don't want the ack timout kicking in
         // checkpointing
-        props.put(PropertyKeys.ENABLE_CHECKPOINTS, Boolean.toString(this.checkpoint));
-
-        return props;
+        settings.setCheckpointEnabled(this.checkpoint);
     }
 
     // Need to separate this logic out of setUp() so that each Test
@@ -79,10 +71,9 @@ public class OutOfOrderAckIdTest extends AbstractConnectionTest {
     protected void createConnection() {
         this.callbacks = getCallbacks();
 
-        Properties props = new Properties();
-        props.putAll(getTestProps());
-        props.putAll(getProps());
-        this.connection = Connections.create((ConnectionCallbacks) callbacks, props);
+        PropertiesFileHelper settings = getTestProps();
+        setProps(settings);
+        this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdTest.java
@@ -56,7 +56,7 @@ public class OutOfOrderAckIdTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDEndpoints");
         settings.setBlockingTimeoutMS(30000);
         settings.setUnresponsiveMS(-1); //no dead channel detection
@@ -72,7 +72,7 @@ public class OutOfOrderAckIdTest extends AbstractConnectionTest {
         this.callbacks = getCallbacks();
 
         PropertiesFileHelper settings = getTestProps();
-        setProps(settings);
+        configureProps(settings);
         this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdWithFailTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdWithFailTest.java
@@ -92,7 +92,7 @@ public class OutOfOrderAckIdWithFailTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDFailEndpoints");
         settings.setBlockingTimeoutMS(30000);
         settings.setUnresponsiveMS(-1); //no dead channel detection

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdWithFailTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdWithFailTest.java
@@ -1,24 +1,13 @@
 package com.splunk.cloudfwd.test.mock;
 
-import com.splunk.cloudfwd.ConnectionCallbacks;
-import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.EventBatch;
 import com.splunk.cloudfwd.LifecycleEvent;
-import com.splunk.cloudfwd.PropertyKeys;
-import com.splunk.cloudfwd.error.HecChannelDeathException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.error.HecMaxRetriesException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDFailEndpoints;
-
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
-
-import java.util.ArrayList;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
@@ -41,7 +30,7 @@ import org.junit.Test;
  */
 /**
  *
- * @author meema 
+ * @author ghendrey
  */
 public class OutOfOrderAckIdWithFailTest extends AbstractConnectionTest {
 
@@ -53,10 +42,10 @@ public class OutOfOrderAckIdWithFailTest extends AbstractConnectionTest {
     protected BasicCallbacks getCallbacks() {
       return new BasicCallbacks(n){
            
-          @Override
+        @Override
           public boolean shouldFail(){
-              return true;
-          }          
+          return true;
+        }          
         @Override
         protected boolean isExpectedFailureType(Exception e){
           return (e instanceof HecServerErrorResponseException &&
@@ -103,18 +92,14 @@ public class OutOfOrderAckIdWithFailTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDFailEndpoints");
-        props.put(BLOCKING_TIMEOUT_MS, "30000");
-        props.put(PropertyKeys.UNRESPONSIVE_MS, "-1"); //no dead channel detection
-        props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "4");
-        props.put(PropertyKeys.ACK_TIMEOUT_MS, "60000"); //we don't want the ack timout kicking in
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDFailEndpoints");
+        settings.setBlockingTimeoutMS(30000);
+        settings.setUnresponsiveMS(-1); //no dead channel detection
+        settings.setMaxTotalChannels(4);
+        settings.setAckTimeoutMS(60000); //we don't want the ack timout kicking in
         // checkpointing
-        props.put(PropertyKeys.ENABLE_CHECKPOINTS, "true");
-
-        return props;
+        settings.setCheckpointEnabled(true);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderIdTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderIdTest.java
@@ -40,7 +40,7 @@ public class OutOfOrderIdTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setCheckpointEnabled(false);
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderIdTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderIdTest.java
@@ -2,10 +2,9 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.EventBatch;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,10 +40,8 @@ public class OutOfOrderIdTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(PropertyKeys.ENABLE_CHECKPOINTS, "false");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setCheckpointEnabled(false);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ResendOnCatchingRuntimExceptionTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ResendOnCatchingRuntimExceptionTest.java
@@ -2,12 +2,9 @@ package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.PropertyKeys;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_KEY;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 import com.splunk.cloudfwd.impl.sim.errorgen.runtimeexceptions.ExceptionsEndpoint;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,16 +31,13 @@ import org.junit.Test;
 public class ResendOnCatchingRuntimExceptionTest extends AbstractConnectionTest {
 
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
-    props.put(MOCK_HTTP_KEY, "true");
-    props.put(MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.runtimeexceptions.ExceptionsEndpoint");
-    props.put(PropertyKeys.EVENT_BATCH_SIZE, "0"); //make sure no batching
-    props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "1"); //so we insure we resend on same channel   
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setMockHttp(true);
+    settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.runtimeexceptions.ExceptionsEndpoint");
+    settings.setEventBatchSize(0); //make sure no batching
+    settings.setMaxTotalChannels(1); //so we insure we resend on same channel
     //in the ExceptionsEndpoint, error prob is 0.5. So 20 gives us 1/2^20  chance of never getting the message through
-    props.put(PropertyKeys.RETRIES, "20");
-    return props;
+    settings.setMaxRetries(20);
   }
 
   @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ResendOnCatchingRuntimExceptionTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ResendOnCatchingRuntimExceptionTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class ResendOnCatchingRuntimExceptionTest extends AbstractConnectionTest {
 
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setMockHttp(true);
     settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.runtimeexceptions.ExceptionsEndpoint");
     settings.setEventBatchSize(0); //make sure no batching

--- a/src/test/java/com/splunk/cloudfwd/test/mock/SessionCookiesTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/SessionCookiesTest.java
@@ -1,11 +1,10 @@
 package com.splunk.cloudfwd.test.mock;
 
-
 import com.splunk.cloudfwd.Connection;
 import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.impl.sim.errorgen.cookies.UpdateableCookieEndpoints;
 import com.splunk.cloudfwd.impl.util.HecHealthImpl;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,7 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 
 public class SessionCookiesTest extends AbstractConnectionTest {
@@ -57,13 +55,9 @@ public class SessionCookiesTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(PropertyKeys.MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.errorgen.cookies.UpdateableCookieEndpoints");
-        props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "1");
-
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.cookies.UpdateableCookieEndpoints");
+        settings.setMaxTotalChannels(1);
     }
 
 }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/SessionCookiesTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/SessionCookiesTest.java
@@ -55,7 +55,7 @@ public class SessionCookiesTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.cookies.UpdateableCookieEndpoints");
         settings.setMaxTotalChannels(1);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/SlideHighwaterOnFailTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/SlideHighwaterOnFailTest.java
@@ -3,6 +3,7 @@ package com.splunk.cloudfwd.test.mock;
 import com.splunk.cloudfwd.error.HecChannelDeathException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 
@@ -13,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 import com.splunk.cloudfwd.EventBatch;
-import com.splunk.cloudfwd.PropertyKeys;
 
 /**
  * Created by meemax by 10/24/2017
@@ -23,23 +23,21 @@ public class SlideHighwaterOnFailTest extends AbstractConnectionTest {
     private static final Logger LOG = LoggerFactory.getLogger(SlideHighwaterOnFailTest.class.getName());
 
     @Override
-    protected Properties getProps() {
+    protected void setProps(PropertiesFileHelper settings) {
       Properties props = new Properties();
       //A realistic value of BLOCKING_TIMEOUT_MS would be 1 or more MINUTES, but let's not
       //make this test run too slowly. The point is, we want to SEE the HecConnectionTimeout
       //happen repeatedly, until the message goes through
-      props.put(PropertyKeys.BLOCKING_TIMEOUT_MS, "100"); //block for 100 ms before HecConnectionTimeout
+      settings.setBlockingTimeoutMS(100); //block for 100 ms before HecConnectionTimeout
       //install an endpoint that takes 10 seconds to return an ack
-      props.put(PropertyKeys.MOCK_HTTP_CLASSNAME,
-              "com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
-      props.put(PropertyKeys.MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL, "1");
-      props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "1");
-      props.put(PropertyKeys.ACK_TIMEOUT_MS, "60000"); //we don't want the ack timout kicking in
-      props.put(PropertyKeys.ACK_POLL_MS, "250");
-      props.put(PropertyKeys.RETRIES, "2");
-      props.put(PropertyKeys.UNRESPONSIVE_MS, "100"); //for this test, lets QUICKLY determine the channel is dead
-      props.put(PropertyKeys.ENABLE_CHECKPOINTS, "true");
-      return props;
+      settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
+      settings.setMaxUnackedEventBatchPerChannel(1);
+      settings.setMaxTotalChannels(1);
+      settings.setAckTimeoutMS(60000); //we don't want the ack timout kicking in
+      settings.setAckPollMS(250);
+      settings.setMaxRetries(2);
+      settings.setUnresponsiveMS(100); //for this test, lets QUICKLY determine the channel is dead
+      settings.setCheckpointEnabled(true);
     }
     
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/SlideHighwaterOnFailTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/SlideHighwaterOnFailTest.java
@@ -23,7 +23,7 @@ public class SlideHighwaterOnFailTest extends AbstractConnectionTest {
     private static final Logger LOG = LoggerFactory.getLogger(SlideHighwaterOnFailTest.class.getName());
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
       Properties props = new Properties();
       //A realistic value of BLOCKING_TIMEOUT_MS would be 1 or more MINUTES, but let's not
       //make this test run too slowly. The point is, we want to SEE the HecConnectionTimeout

--- a/src/test/java/com/splunk/cloudfwd/test/mock/SuperSimpleExample.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/SuperSimpleExample.java
@@ -5,12 +5,11 @@ import com.splunk.cloudfwd.ConnectionCallbacks;
 import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.EventBatch;
 import com.splunk.cloudfwd.RawEvent;
-import java.util.Properties;
 import com.splunk.cloudfwd.EventWithMetadata;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static com.splunk.cloudfwd.PropertyKeys.*;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -76,21 +75,21 @@ public class SuperSimpleExample {
     }; //end callbacks
 
     //overide defaults in cloudfwd.properties
-    Properties customization = new Properties();
-    customization.put(COLLECTOR_URI, "https://127.0.0.1:8088");
-    customization.put(TOKEN, "ad9017fd-4adb-4545-9f7a-62a8d28ba7b3");
-    customization.put(UNRESPONSIVE_MS, "100000");//100 sec - Kill unresponsive channel
-    customization.put(MOCK_HTTP_KEY, "true");
-    customization.put(MAX_TOTAL_CHANNELS, "8"); //increase this to increase parallelism
-    customization.put(CHANNELS_PER_DESTINATION, "8"); //increase this to increase parallelism
-    customization.put(ENABLE_CHECKPOINTS, "true"); 
+    PropertiesFileHelper customization = PropertiesFileHelper.fromPropsFile("/cloudfwd.properties");
+    customization.setUrls("https://127.0.0.1:8088");
+    customization.setToken("ad9017fd-4adb-4545-9f7a-62a8d28ba7b3");
+    customization.setUnresponsiveMS(100000);//100 sec - Kill unresponsive channel
+    customization.setMockHttp(true);
+    customization.setMaxTotalChannels(8); //increase this to increase parallelism
+    customization.setChannelsPerDestination(8); //increase this to increase parallelism
+    customization.setCheckpointEnabled(true);
 
     //date formatter for sending 'raw' event
     SimpleDateFormat dateFormat = new SimpleDateFormat(
             "yyyy-MM-dd HH:mm:ss");//one of many supported Splunk timestamp formats
 
     //SEND TEXT EVENTS TO HEC 'RAW' ENDPOINT
-    try (Connection c = Connections.create(callbacks, customization);) {
+    try (Connection c = Connections.create(callbacks, customization)) {
       c.getSettings().setEventBatchSize(1024 * 16); //16kB send buffering -- in practice use a much larger buffer
       c.getSettings().setAckTimeoutMS(60000); //60 sec
       for (int seqno = 1; seqno <= numEvents; seqno++) {//sequence numbers can be any Comparable Object

--- a/src/test/java/com/splunk/cloudfwd/test/mock/UnhealthyEndpointTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/UnhealthyEndpointTest.java
@@ -49,7 +49,7 @@ public final class UnhealthyEndpointTest extends AbstractConnectionTest {
   }
 
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     //props.put(PropertiesFileHelper.MOCK_HTTP_KEY, "true");
     //simulate a non-sticky endpoint
     settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.TriggerableUnhealthyEndpoints");

--- a/src/test/java/com/splunk/cloudfwd/test/mock/UnhealthyEndpointTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/UnhealthyEndpointTest.java
@@ -3,12 +3,10 @@ package com.splunk.cloudfwd.test.mock;
 import com.splunk.cloudfwd.EventBatch;
 import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import static com.splunk.cloudfwd.PropertyKeys.*;
-import static com.splunk.cloudfwd.PropertyKeys.UNRESPONSIVE_MS;
 import com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.TriggerableUnhealthyEndpoints;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
@@ -51,19 +49,15 @@ public final class UnhealthyEndpointTest extends AbstractConnectionTest {
   }
 
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
+  protected void setProps(PropertiesFileHelper settings) {
     //props.put(PropertiesFileHelper.MOCK_HTTP_KEY, "true");
     //simulate a non-sticky endpoint
-    props.put(MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.TriggerableUnhealthyEndpoints");
-    props.put(MAX_TOTAL_CHANNELS, "1");
-    props.put(MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL,"1000");
-    props.put(ACK_POLL_MS, "250");
-    props.put(HEALTH_POLL_MS, "250");
-    props.put(UNRESPONSIVE_MS, "-1"); //disable dead channel removal
-
-    return props;
+    settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.TriggerableUnhealthyEndpoints");
+    settings.setMaxTotalChannels(1);
+    settings.setMaxUnackedEventBatchPerChannel(1000);
+    settings.setAckPollMS(250);
+    settings.setHealthPollMS(250);
+    settings.setUnresponsiveMS(-1); //disable dead channel removal
   }
 
   @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/UnvalidatedBytesTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/UnvalidatedBytesTest.java
@@ -3,9 +3,8 @@ package com.splunk.cloudfwd.test.mock;
 import com.splunk.cloudfwd.Connection;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
 /*
@@ -45,14 +44,12 @@ public class UnvalidatedBytesTest extends AbstractConnectionTest {
   public void testUnvalidatedBytesToEvents() throws InterruptedException, HecConnectionTimeoutException{
     super.connection.getSettings().setHecEndpointType(Connection.HecEndpoint.STRUCTURED_EVENTS_ENDPOINT);
     sendEvents();
-  }  
-  
-    protected Properties getProps() {
-    Properties props = new Properties(); //default behavior is no "hard coded" test-specific properties
-    props.put(PropertyKeys.EVENT_BATCH_SIZE,  "16000");
-    //props.put(PropertyKeys.MOCK_HTTP_KEY, "false");
+  }
+
+  protected void setProps(PropertiesFileHelper settings) {
+    settings.setEventBatchSize(16000);
+    //settings.setMockHttp(false);
     super.eventType = Event.Type.UNKNOWN;
-    return props;
   }
   
   

--- a/src/test/java/com/splunk/cloudfwd/test/mock/UnvalidatedBytesTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/UnvalidatedBytesTest.java
@@ -46,7 +46,7 @@ public class UnvalidatedBytesTest extends AbstractConnectionTest {
     sendEvents();
   }
 
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     settings.setEventBatchSize(16000);
     //settings.setMockHttp(false);
     super.eventType = Event.Type.UNKNOWN;

--- a/src/test/java/com/splunk/cloudfwd/test/mock/UrlProtocolTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/UrlProtocolTest.java
@@ -1,11 +1,9 @@
 package com.splunk.cloudfwd.test.mock;
 
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 
 import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CONFIGURATION_EXCEPTION;
-
-import java.util.Properties;
 
 /*
  * Copyright 2017 Splunk, Inc..
@@ -26,10 +24,8 @@ import java.util.Properties;
 
 public class UrlProtocolTest extends ExceptionConnInstantiationTest {
      @Override
-    protected Properties getProps() {
-       Properties props = new Properties();
-       props.put(PropertyKeys.COLLECTOR_URI, "http://foo.com"); //http is not supported protocol. Must be https
-       return props;
+     protected void setProps(PropertiesFileHelper settings) {
+         settings.setUrls("http://foo.com"); //http is not supported protocol. Must be https
     }
     
     protected boolean isExpectedConnInstantiationException(Exception e) {

--- a/src/test/java/com/splunk/cloudfwd/test/mock/UrlProtocolTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/UrlProtocolTest.java
@@ -24,7 +24,7 @@ import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CONFIGU
 
 public class UrlProtocolTest extends ExceptionConnInstantiationTest {
      @Override
-     protected void setProps(PropertiesFileHelper settings) {
+     protected void configureProps(PropertiesFileHelper settings) {
          settings.setUrls("http://foo.com"); //http is not supported protocol. Must be https
     }
     

--- a/src/test/java/com/splunk/cloudfwd/test/mock/WatchdogChannelKillerTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/WatchdogChannelKillerTest.java
@@ -16,15 +16,12 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.HecHealth;
-import com.splunk.cloudfwd.PropertyKeys;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_KEY;
 import com.splunk.cloudfwd.error.HecAcknowledgmentTimeoutException;
 import com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import java.util.List;
-import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,18 +38,15 @@ import org.junit.Test;
 public class WatchdogChannelKillerTest extends AbstractConnectionTest {
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.setProperty(MOCK_HTTP_KEY, "true");
-        props.setProperty(MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
-        props.setProperty(PropertyKeys.EVENT_BATCH_SIZE, "0"); //make sure no batching
-        props.setProperty(PropertyKeys.MAX_TOTAL_CHANNELS, "1"); //so we insure we resend on same channel  
-        props.setProperty(PropertyKeys.CHANNEL_DECOM_MS, "500"); //decommission the channel after 500ms  
-        props.setProperty(PropertyKeys.ACK_TIMEOUT_MS, "250"); //time out ack in 250ms
-        props.setProperty(PropertyKeys.CHANNEL_QUIESCE_TIMEOUT_MS, "750"); //watchdog to kill the channel in 750ms 
-        props.setProperty(PropertyKeys.MAX_UNACKED_EVENT_BATCHES_PER_CHANNEL, "1");       
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttp(true);
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
+        settings.setEventBatchSize(0); //make sure no batching
+        settings.setMaxRetries(1); //so we insure we resend on same channel  
+        settings.setChannelDecomMS(500); //decommission the channel after 500ms  
+        settings.setAckTimeoutMS(250); //time out ack in 250ms
+        settings.setChannelQuiesceTimeoutMS(750); //watchdog to kill the channel in 750ms
+        settings.setMaxUnackedEventBatchPerChannel(1);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/WatchdogChannelKillerTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/WatchdogChannelKillerTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 public class WatchdogChannelKillerTest extends AbstractConnectionTest {
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttp(true);
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
         settings.setEventBatchSize(0); //make sure no batching

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/AbstractHealthCheckTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/AbstractHealthCheckTest.java
@@ -4,11 +4,11 @@ import com.splunk.cloudfwd.ConnectionCallbacks;
 import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 
 import java.util.ArrayList;
-import java.util.Properties;
 
 /**
  * Created by mhora on 10/4/17.
@@ -30,12 +30,11 @@ public class AbstractHealthCheckTest extends AbstractConnectionTest {
     // Need to separate this logic out of setUp() so that each Test
     // can use different simulated endpoints
     protected void createConnection(LifecycleEvent.Type problemType) {
-        Properties props = new Properties();
-        props.putAll(getTestProps());
-        props.putAll(getProps());
+        PropertiesFileHelper settings = this.getTestProps();
+        setProps(settings);
         boolean gotException = false;
         try{
-            this.connection = Connections.create((ConnectionCallbacks) callbacks, props);
+            connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         }catch(Exception e){
             Assert.assertTrue("Expected HecServerErrorResponseException but got "+ e,  e instanceof HecServerErrorResponseException);
             HecServerErrorResponseException servRespExc = (HecServerErrorResponseException) e;

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/AbstractHealthCheckTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/AbstractHealthCheckTest.java
@@ -31,7 +31,7 @@ public class AbstractHealthCheckTest extends AbstractConnectionTest {
     // can use different simulated endpoints
     protected void createConnection(LifecycleEvent.Type problemType) {
         PropertiesFileHelper settings = this.getTestProps();
-        setProps(settings);
+        configureProps(settings);
         boolean gotException = false;
         try{
             connection = Connections.create((ConnectionCallbacks) callbacks, settings);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckAcksDisabledTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckAcksDisabledTest.java
@@ -17,7 +17,7 @@ public class HealthCheckAcksDisabledTest extends AbstractHealthCheckTest {
     private static final Logger LOG = LoggerFactory.getLogger(HealthCheckAcksDisabledTest.class.getName());
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.AckDisabledEndpoints");
         settings.setBlockingTimeoutMS(3000);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckAcksDisabledTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckAcksDisabledTest.java
@@ -1,16 +1,14 @@
 package com.splunk.cloudfwd.test.mock.health_check_tests;
 
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
 import static com.splunk.cloudfwd.LifecycleEvent.Type.ACK_DISABLED;
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 
 /**
  * Created by mhora on 10/4/17.
@@ -19,12 +17,9 @@ public class HealthCheckAcksDisabledTest extends AbstractHealthCheckTest {
     private static final Logger LOG = LoggerFactory.getLogger(HealthCheckAcksDisabledTest.class.getName());
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-           "com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.AckDisabledEndpoints");
-        props.put(BLOCKING_TIMEOUT_MS, "3000");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.AckDisabledEndpoints");
+        settings.setBlockingTimeoutMS(3000);
     }
 
     @Test

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInDetentionTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInDetentionTest.java
@@ -2,15 +2,12 @@ package com.splunk.cloudfwd.test.mock.health_check_tests;
 
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
-
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 
 /**
  * Created by mhora on 10/4/17.
@@ -19,12 +16,9 @@ public class HealthCheckInDetentionTest extends AbstractHealthCheckTest {
     private static final Logger LOG = LoggerFactory.getLogger(HealthCheckInDetentionTest.class.getName());
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.indexer.InDetentionEndpoints");
-        props.put(BLOCKING_TIMEOUT_MS, "3000");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.InDetentionEndpoints");
+        settings.setBlockingTimeoutMS(3000);
     }
 
     @Test

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInDetentionTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInDetentionTest.java
@@ -16,7 +16,7 @@ public class HealthCheckInDetentionTest extends AbstractHealthCheckTest {
     private static final Logger LOG = LoggerFactory.getLogger(HealthCheckInDetentionTest.class.getName());
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.InDetentionEndpoints");
         settings.setBlockingTimeoutMS(3000);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidAuth.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidAuth.java
@@ -1,15 +1,12 @@
 package com.splunk.cloudfwd.test.mock.health_check_tests;
 
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.test.mock.health_check_tests.AbstractHealthCheckTest;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
 import static com.splunk.cloudfwd.LifecycleEvent.Type.INVALID_AUTH;
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 
 /**
  * Created by mhora on 10/4/17.
@@ -17,12 +14,9 @@ import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 public class HealthCheckInvalidAuth extends AbstractHealthCheckTest {
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidAuthEndpoints");
-        props.put(BLOCKING_TIMEOUT_MS, "3000");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidAuthEndpoints");
+        settings.setBlockingTimeoutMS(3000);
     }
 
     @Test

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidAuth.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidAuth.java
@@ -14,7 +14,7 @@ import static com.splunk.cloudfwd.LifecycleEvent.Type.INVALID_AUTH;
 public class HealthCheckInvalidAuth extends AbstractHealthCheckTest {
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidAuthEndpoints");
         settings.setBlockingTimeoutMS(3000);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidTokenTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidTokenTest.java
@@ -1,15 +1,12 @@
 package com.splunk.cloudfwd.test.mock.health_check_tests;
 
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.test.mock.health_check_tests.AbstractHealthCheckTest;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
 import static com.splunk.cloudfwd.LifecycleEvent.Type.INVALID_TOKEN;
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 
 /**
  * Created by mhora on 10/4/17.
@@ -17,12 +14,9 @@ import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 public class HealthCheckInvalidTokenTest extends AbstractHealthCheckTest {
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidTokenEndpoints");
-        props.put(BLOCKING_TIMEOUT_MS, "3000");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidTokenEndpoints");
+        settings.setBlockingTimeoutMS(3000);
     }
 
     @Test

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidTokenTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidTokenTest.java
@@ -14,7 +14,7 @@ import static com.splunk.cloudfwd.LifecycleEvent.Type.INVALID_TOKEN;
 public class HealthCheckInvalidTokenTest extends AbstractHealthCheckTest {
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidTokenEndpoints");
         settings.setBlockingTimeoutMS(3000);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/AbstractHecServerErrorResponseTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/AbstractHecServerErrorResponseTest.java
@@ -4,12 +4,12 @@ import com.splunk.cloudfwd.*;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Properties;
 
 /**
  * Created by mhora on 10/3/17.
@@ -65,20 +65,18 @@ public abstract class AbstractHecServerErrorResponseTest extends AbstractConnect
     // Need to separate this logic out of setUp() so that each Test
     // can use different simulated endpoints
     protected void createConnection() {
-        Properties props = new Properties();
-        props.putAll(getTestProps());
-        props.putAll(getProps());
-        this.connection = Connections.create((ConnectionCallbacks) callbacks, props);
+        PropertiesFileHelper settings = this.getTestProps();
+        setProps(settings);
+        connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }
 
     protected void createConnection(LifecycleEvent.Type problemType) {
-        Properties props = new Properties();
-        props.putAll(getTestProps());
-        props.putAll(getProps());
+        PropertiesFileHelper settings = this.getTestProps();
+        this.setProps(settings);
         boolean gotException = false;
         try{
-            this.connection = Connections.create((ConnectionCallbacks) callbacks, props);
+            connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         }catch(Exception e){
             Assert.assertTrue("Expected HecServerErrorResponseException",  e instanceof HecServerErrorResponseException);
             HecServerErrorResponseException servRespExc = (HecServerErrorResponseException) e;

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/AbstractHecServerErrorResponseTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/AbstractHecServerErrorResponseTest.java
@@ -66,14 +66,14 @@ public abstract class AbstractHecServerErrorResponseTest extends AbstractConnect
     // can use different simulated endpoints
     protected void createConnection() {
         PropertiesFileHelper settings = this.getTestProps();
-        setProps(settings);
+        configureProps(settings);
         connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }
 
     protected void createConnection(LifecycleEvent.Type problemType) {
         PropertiesFileHelper settings = this.getTestProps();
-        this.setProps(settings);
+        this.configureProps(settings);
         boolean gotException = false;
         try{
             connection = Connections.create((ConnectionCallbacks) callbacks, settings);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseAcksDisabledTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseAcksDisabledTest.java
@@ -4,16 +4,12 @@ import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
-
-import static com.splunk.cloudfwd.PropertyKeys.ACK_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 
 /**
  * Created by mhora on 10/3/17.
@@ -45,13 +41,10 @@ public class HecServerErrorResponseAcksDisabledTest extends AbstractHecServerErr
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props =  new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.AckDisabledEndpoints");
-        props.put(ACK_TIMEOUT_MS, "500000");  //in this case we expect to see HecConnectionTimeoutException
-        props.put(BLOCKING_TIMEOUT_MS, "5000");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.AckDisabledEndpoints");
+        settings.setAckTimeoutMS(500000); //in this case we expect to see HecConnectionTimeoutException
+        settings.setBlockingTimeoutMS(5000);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseAcksDisabledTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseAcksDisabledTest.java
@@ -41,7 +41,7 @@ public class HecServerErrorResponseAcksDisabledTest extends AbstractHecServerErr
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.AckDisabledEndpoints");
         settings.setAckTimeoutMS(500000); //in this case we expect to see HecConnectionTimeoutException
         settings.setBlockingTimeoutMS(5000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKAndExpectAckTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKAndExpectAckTimeoutTest.java
@@ -53,7 +53,7 @@ public class HecServerErrorResponseIndexerBusyButHealthCheckOKAndExpectAckTimeou
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostIndexerBusyEndpoints");
         settings.setAckTimeoutMS(2000); //in this case we excpect to see HecConnectionTimeoutException
         settings.setBlockingTimeoutMS(5000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKAndExpectAckTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKAndExpectAckTimeoutTest.java
@@ -4,17 +4,14 @@ import com.splunk.cloudfwd.error.HecAcknowledgmentTimeoutException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
 import static com.splunk.cloudfwd.LifecycleEvent.Type.INDEXER_BUSY;
-import static com.splunk.cloudfwd.PropertyKeys.ACK_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 
 /**
  * Created by mhora on 10/3/17.
@@ -56,13 +53,10 @@ public class HecServerErrorResponseIndexerBusyButHealthCheckOKAndExpectAckTimeou
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostIndexerBusyEndpoints");
-        props.put(ACK_TIMEOUT_MS, "2000");  //in this case we expect to see HecConnectionTimeoutException
-        props.put(BLOCKING_TIMEOUT_MS, "5000");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostIndexerBusyEndpoints");
+        settings.setAckTimeoutMS(2000); //in this case we excpect to see HecConnectionTimeoutException
+        settings.setBlockingTimeoutMS(5000);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKTest.java
@@ -2,19 +2,15 @@ package com.splunk.cloudfwd.test.mock.hec_server_error_response_tests;
 
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
+import com.splunk.cloudfwd.error.HecMaxRetriesException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
-
 import static com.splunk.cloudfwd.LifecycleEvent.Type.INDEXER_BUSY;
-import static com.splunk.cloudfwd.PropertyKeys.ACK_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
-import com.splunk.cloudfwd.error.HecMaxRetriesException;
 
 /**
  * Created by mhora on 10/3/17.
@@ -55,13 +51,10 @@ public class HecServerErrorResponseIndexerBusyButHealthCheckOKTest extends Abstr
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props =  new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostIndexerBusyEndpoints");
-        props.put(ACK_TIMEOUT_MS, "500000");  //in this case we expect to see HecConnectionTimeoutException
-        props.put(BLOCKING_TIMEOUT_MS, "5000");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostIndexerBusyEndpoints");
+        settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
+        settings.setBlockingTimeoutMS(5000);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKTest.java
@@ -51,7 +51,7 @@ public class HecServerErrorResponseIndexerBusyButHealthCheckOKTest extends Abstr
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostIndexerBusyEndpoints");
         settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
         settings.setBlockingTimeoutMS(5000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidEventNumber.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidEventNumber.java
@@ -58,7 +58,7 @@ public class HecServerErrorResponseInvalidEventNumber extends AbstractHecServerE
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.invalidvent.InvalidEventEndpoint");
         settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
         settings.setBlockingTimeoutMS(5000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidEventNumber.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidEventNumber.java
@@ -5,17 +5,13 @@ import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
-
-import static com.splunk.cloudfwd.PropertyKeys.ACK_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 
 /**
  * Created by mhora on 10/3/17.
@@ -62,13 +58,10 @@ public class HecServerErrorResponseInvalidEventNumber extends AbstractHecServerE
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.errorgen.invalidvent.InvalidEventEndpoint");
-        props.put(ACK_TIMEOUT_MS, "500000");  //in this case we expect to see HecConnectionTimeoutException
-        props.put(BLOCKING_TIMEOUT_MS, "5000");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.invalidvent.InvalidEventEndpoint");
+        settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
+        settings.setBlockingTimeoutMS(5000);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidTokenTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidTokenTest.java
@@ -4,15 +4,11 @@ import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
-
-import static com.splunk.cloudfwd.PropertyKeys.ACK_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 
 /**
  * Created by mhora on 10/3/17.
@@ -43,13 +39,10 @@ public class HecServerErrorResponseInvalidTokenTest extends AbstractHecServerErr
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = super.getProps();
-        props.put(MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidTokenEndpoints");
-        props.put(ACK_TIMEOUT_MS, "500000");  //in this case we expect to see HecConnectionTimeoutException
-        props.put(BLOCKING_TIMEOUT_MS, "5000");
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidTokenEndpoints");
+        settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
+        settings.setBlockingTimeoutMS(5000);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidTokenTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidTokenTest.java
@@ -39,7 +39,7 @@ public class HecServerErrorResponseInvalidTokenTest extends AbstractHecServerErr
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidTokenEndpoints");
         settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
         settings.setBlockingTimeoutMS(5000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseNoAckIdEvent.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseNoAckIdEvent.java
@@ -50,7 +50,7 @@ public class HecServerErrorResponseNoAckIdEvent extends AbstractHecServerErrorRe
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         //in this case, the pre-flight check will pass, and we are simulating were we detect acks disabled on event post
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostNoAckIdEndpoints");
         settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseNoAckIdEvent.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseNoAckIdEvent.java
@@ -3,16 +3,13 @@ package com.splunk.cloudfwd.test.mock.hec_server_error_response_tests;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
-import static com.splunk.cloudfwd.PropertyKeys.ACK_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CONFIGURATION_EXCEPTION;
 
 /**
@@ -53,14 +50,11 @@ public class HecServerErrorResponseNoAckIdEvent extends AbstractHecServerErrorRe
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
+    protected void setProps(PropertiesFileHelper settings) {
         //in this case, the pre-flight check will pass, and we are simulating were we detect acks disabled on event post
-        props.put(MOCK_HTTP_CLASSNAME,
-                "com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostNoAckIdEndpoints");
-        props.put(ACK_TIMEOUT_MS, "500000");  //in this case we expect to see HecConnectionTimeoutException
-        props.put(BLOCKING_TIMEOUT_MS, "5000");
-        return props;
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostNoAckIdEndpoints");
+        settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
+        settings.setBlockingTimeoutMS(5000);
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionAllTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionAllTest.java
@@ -32,7 +32,7 @@ public class InDetentionAllTest extends AbstractInDetentionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.InDetentionEndpoints");
         settings.setBlockingTimeoutMS(30000);
         settings.setUnresponsiveMS(-1); //no dead channel detection
@@ -41,7 +41,7 @@ public class InDetentionAllTest extends AbstractInDetentionTest {
 
     protected void createConnection(LifecycleEvent.Type problemType) {
         PropertiesFileHelper settings = this.getTestProps();
-        this.setProps(settings);
+        this.configureProps(settings);
         boolean gotException = false;
         try{
             this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionAllTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionAllTest.java
@@ -3,17 +3,11 @@ package com.splunk.cloudfwd.test.mock.in_detention_tests;
 import com.splunk.cloudfwd.ConnectionCallbacks;
 import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.LifecycleEvent;
-import com.splunk.cloudfwd.PropertyKeys;
-import com.splunk.cloudfwd.test.mock.in_detention_tests.AbstractInDetentionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Properties;
-
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 
 /**
  * Created by mhora on 10/4/17.
@@ -38,24 +32,19 @@ public class InDetentionAllTest extends AbstractInDetentionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-                props.put(MOCK_HTTP_CLASSNAME,
-                        "com.splunk.cloudfwd.impl.sim.errorgen.indexer.InDetentionEndpoints");
-        props.put(BLOCKING_TIMEOUT_MS, "30000");
-        props.put(PropertyKeys.UNRESPONSIVE_MS, "-1"); //no dead channel detection
-        props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "2");
-
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.InDetentionEndpoints");
+        settings.setBlockingTimeoutMS(30000);
+        settings.setUnresponsiveMS(-1); //no dead channel detection
+        settings.setMaxTotalChannels(2);
     }
 
     protected void createConnection(LifecycleEvent.Type problemType) {
-        Properties props = new Properties();
-        props.putAll(getTestProps());
-        props.putAll(getProps());
+        PropertiesFileHelper settings = this.getTestProps();
+        this.setProps(settings);
         boolean gotException = false;
         try{
-            this.connection = Connections.create((ConnectionCallbacks) callbacks, props);
+            this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         }catch(Exception e){
             Assert.assertTrue("Expected HecServerErrorResponseException",  e instanceof HecServerErrorResponseException);
             HecServerErrorResponseException servRespExc = (HecServerErrorResponseException) e;

--- a/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionSomeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionSomeTest.java
@@ -30,7 +30,7 @@ public class InDetentionSomeTest extends AbstractInDetentionTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
+    protected void configureProps(PropertiesFileHelper settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.SomeInDetentionEndpoints");
         settings.setBlockingTimeoutMS(30000);
         settings.setUnresponsiveMS(-1); //no dead channel detection
@@ -46,7 +46,7 @@ public class InDetentionSomeTest extends AbstractInDetentionTest {
     // can use different simulated endpoints
     protected void createConnection() {
         PropertiesFileHelper settings = this.getTestProps();
-        this.setProps(settings);
+        this.configureProps(settings);
         this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionSomeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionSomeTest.java
@@ -1,15 +1,10 @@
 package com.splunk.cloudfwd.test.mock.in_detention_tests;
 
-import com.splunk.cloudfwd.PropertyKeys;
-import com.splunk.cloudfwd.test.mock.in_detention_tests.AbstractInDetentionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.*;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import org.junit.Test;
-import java.util.Properties;
-
-import static com.splunk.cloudfwd.PropertyKeys.BLOCKING_TIMEOUT_MS;
-import static com.splunk.cloudfwd.PropertyKeys.MOCK_HTTP_CLASSNAME;
 
 /**
  * Created by mhora on 10/4/17.
@@ -35,15 +30,11 @@ public class InDetentionSomeTest extends AbstractInDetentionTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties props = new Properties();
-        props.put(MOCK_HTTP_CLASSNAME,
-            "com.splunk.cloudfwd.impl.sim.errorgen.indexer.SomeInDetentionEndpoints");
-        props.put(BLOCKING_TIMEOUT_MS, "30000");
-        props.put(PropertyKeys.UNRESPONSIVE_MS, "-1"); //no dead channel detection
-        props.put(PropertyKeys.MAX_TOTAL_CHANNELS, "2");
-
-        return props;
+    protected void setProps(PropertiesFileHelper settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.SomeInDetentionEndpoints");
+        settings.setBlockingTimeoutMS(30000);
+        settings.setUnresponsiveMS(-1); //no dead channel detection
+        settings.setMaxTotalChannels(2);
     }
 
     @Override
@@ -54,10 +45,9 @@ public class InDetentionSomeTest extends AbstractInDetentionTest {
     // Need to separate this logic out of setUp() so that each Test
     // can use different simulated endpoints
     protected void createConnection() {
-        Properties props = new Properties();
-        props.putAll(getTestProps());
-        props.putAll(getProps());
-        this.connection = Connections.create((ConnectionCallbacks) callbacks, props);
+        PropertiesFileHelper settings = this.getTestProps();
+        this.setProps(settings);
+        this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/perf/AbstractPerformanceTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/AbstractPerformanceTest.java
@@ -2,11 +2,10 @@ package com.splunk.cloudfwd.test.perf;
 
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.PropertyKeys;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.mock.ThroughputCalculatorCallback;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
@@ -41,18 +40,17 @@ public abstract class AbstractPerformanceTest extends AbstractConnectionTest {
   }
   @Override
     protected String getTestPropertiesFileName() {
-    return "cloudfwd.properties"; //try as hard as we can to ignore test.properties and not use it
+    return "/cloudfwd.properties"; //try as hard as we can to ignore test.properties and not use it
   }
   
   @Override
-  protected Properties getProps() {
-    Properties props = new Properties(); //default behavior is no "hard coded" test-specific properties
-        //the assumption here is that we are doing performance testing using cloudfwd.properties not test.properties
-    props.put(AbstractConnectionTest.KEY_ENABLE_TEST_PROPERTIES, false);    
+  protected void setProps(PropertiesFileHelper settings) {
+    //default behavior is no "hard coded" test-specific properties
+    //the assumption here is that we are doing performance testing using cloudfwd.properties not test.properties
+    settings.setTestPropertiesEnabled(false);
     //NOT http mock, but real server is the assumption for these tests
-    props.put(PropertyKeys.MOCK_HTTP_KEY, "false");
-    return props;
-  }  
+    settings.setMockHttp(false);
+  }
 
   @Override
   protected void sendEvents() throws InterruptedException, HecConnectionTimeoutException {

--- a/src/test/java/com/splunk/cloudfwd/test/perf/AbstractPerformanceTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/AbstractPerformanceTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractPerformanceTest extends AbstractConnectionTest {
   }
   
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     //default behavior is no "hard coded" test-specific properties
     //the assumption here is that we are doing performance testing using cloudfwd.properties not test.properties
     settings.setTestPropertiesEnabled(false);

--- a/src/test/java/com/splunk/cloudfwd/test/perf/CloseNowInALoopTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/CloseNowInALoopTest.java
@@ -27,6 +27,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -42,14 +44,14 @@ public class CloseNowInALoopTest {
     @Test
     public void loop() throws InterruptedException, ExecutionException{
         int numConnections = 100;
-        Properties props = new Properties();
-        props.setProperty(PropertyKeys.COLLECTOR_URI, "https://127.0.0.1:8088");
-        props.setProperty(PropertyKeys.TOKEN, "7263336d-ac05-4db9-92c3-9536922d11b1");
+        PropertiesFileHelper settings = new PropertiesFileHelper();
+        settings.setUrls("https://127.0.0.1:8088");
+        settings.setToken("7263336d-ac05-4db9-92c3-9536922d11b1");
         List<Connection> connections = Collections.synchronizedList(new ArrayList<>());
         Callable<Connection> callable =()->{
             try{
                 LOG.info("CREATING CONNECTION");
-                Connection c = Connections.create(props);
+                Connection c = Connections.create(settings);
                 connections.add(c);
                 LOG.info("Connections size = " + connections.size());
                 return c;

--- a/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
@@ -2,9 +2,8 @@ package com.splunk.cloudfwd.test.perf;
 
 import com.splunk.cloudfwd.*;
 import com.splunk.cloudfwd.impl.EventBatchImpl;
-import com.splunk.cloudfwd.impl.util.ThreadScheduler;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.mock.ThroughputCalculatorCallback;
-import static com.splunk.cloudfwd.test.util.AbstractConnectionTest.KEY_ENABLE_TEST_PROPERTIES;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Assert;
 import org.junit.Test;
@@ -63,7 +62,7 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
         numSenderThreads = Integer.parseInt(cliProperties.get(NUM_SENDERS_KEY));
         //create executor before connection. Else if connection instantiation fails, NPE on cleanup via null executor
        // ExecutorService senderExecutor = ThreadScheduler.getSharedExecutorInstance("Connection client");
-        ExecutorService senderExecutor =Executors.newFixedThreadPool(numSenderThreads,
+        ExecutorService senderExecutor = Executors.newFixedThreadPool(numSenderThreads,
         (Runnable r) -> new Thread(r, "Connection client")); // second argument is Threadfactory
         readEventsFile();
         //connection.getSettings().setHecEndpointType(Connection.HecEndpoint.RAW_EVENTS_ENDPOINT);
@@ -127,7 +126,7 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
 
     @Override
     protected String getTestPropertiesFileName() {
-        return "cloudfwd.properties"; //try as hard as we can to ignore test.properties and not use it
+        return "/cloudfwd.properties"; //try as hard as we can to ignore test.properties and not use it
     }
 
     // not used
@@ -142,17 +141,18 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
     }
 
     @Override
-    protected Properties getProps() {
-        Properties p = new Properties();
-        if (cliProperties.get(PropertyKeys.TOKEN) != null) {
-            p.put(PropertyKeys.TOKEN, cliProperties.get(PropertyKeys.TOKEN));
+    protected void setProps(PropertiesFileHelper settings) {
+        super.setProps(settings);
+        String token = System.getProperty(PropertyKeys.TOKEN);
+        String url = System.getProperty(PropertyKeys.COLLECTOR_URI);
+        if (System.getProperty(PropertyKeys.TOKEN) != null) {
+            settings.setToken(token);
         }
-        if (cliProperties.get(PropertyKeys.COLLECTOR_URI) != null) {
-            p.put(PropertyKeys.COLLECTOR_URI, cliProperties.get(PropertyKeys.COLLECTOR_URI));
+        if (System.getProperty(PropertyKeys.COLLECTOR_URI) != null) {
+            settings.setUrls(url);
         }
-        p.put(PropertyKeys.MOCK_HTTP_KEY, "false");
-        p.put(KEY_ENABLE_TEST_PROPERTIES, "false");
-        return p;
+        settings.setMockHttp(false);
+        settings.setTestPropertiesEnabled(false);
     }
 
     private void checkAndLogPerformance(boolean shouldAssert) {
@@ -201,25 +201,25 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
         private boolean failed = false;
         private int workerNumber;
         private Connection connection;
+        private ConnectionSettings connectionSettings;
         
         public SenderWorker(int workerNum) throws UnknownHostException{
             this.workerNumber = workerNum;
             this.connection = createAndConfigureConnection();
+            this.connectionSettings = connection.getSettings();
             if (null ==connection){
                 Assert.fail("null connection");
             }
             //to accurately simulate amazon load tests, we need to set the properties AFTER the connection is 
             //instantiated
-            Properties p = new Properties();
             if (cliProperties.get(PropertyKeys.TOKEN) != null) {
-                p.put(PropertyKeys.TOKEN, cliProperties.get(PropertyKeys.TOKEN));
+                connectionSettings.setToken(cliProperties.get(PropertyKeys.TOKEN));
             }
             if (cliProperties.get(PropertyKeys.COLLECTOR_URI) != null) {
-                p.put(PropertyKeys.COLLECTOR_URI, cliProperties.get(PropertyKeys.COLLECTOR_URI));
+                connectionSettings.setUrls(cliProperties.get(PropertyKeys.COLLECTOR_URI));
             }
-            p.put(PropertyKeys.MOCK_HTTP_KEY, "false");
-            p.put(KEY_ENABLE_TEST_PROPERTIES, "false");
-            connection.getSettings().setProperties(p);
+            connectionSettings.setMockHttp(false);
+            connectionSettings.setTestPropertiesEnabled(false);
         }
         public void sendAndWaitForAcks() {
             LOG.info("sender {} starting its send loop", workerNumber);

--- a/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
@@ -141,8 +141,8 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
     }
 
     @Override
-    protected void setProps(PropertiesFileHelper settings) {
-        super.setProps(settings);
+    protected void configureProps(PropertiesFileHelper settings) {
+        super.configureProps(settings);
         String token = System.getProperty(PropertyKeys.TOKEN);
         String url = System.getProperty(PropertyKeys.COLLECTOR_URI);
         if (System.getProperty(PropertyKeys.TOKEN) != null) {

--- a/src/test/java/com/splunk/cloudfwd/test/perf/OncePerSecondLongevityTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/OncePerSecondLongevityTest.java
@@ -1,10 +1,7 @@
 package com.splunk.cloudfwd.test.perf;
 
 import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.PropertyKeys;
-import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-
-import java.util.Properties;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -29,7 +26,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author ghendrey
  */
-public class OncePerSecondLongevityTest extends AbstractConnectionTest {
+public class OncePerSecondLongevityTest extends AbstractPerformanceTest {
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(OncePerSecondLongevityTest.class.getName());
     
     @Test
@@ -52,15 +49,14 @@ public class OncePerSecondLongevityTest extends AbstractConnectionTest {
         }
     }
     
-      @Override
-  protected Properties getProps() {
-    Properties props = new Properties();
+  @Override
+  protected void setProps(PropertiesFileHelper settings) {
+      super.setProps(settings);
     //simulate a non-sticky endpoint
-    props.put(PropertyKeys.MOCK_HTTP_KEY,"false");
-    props.put(PropertyKeys.EVENT_BATCH_SIZE, "0"); //send immediately
-    props.put(PropertyKeys.ACK_TIMEOUT_MS, "180000"); //3 minute ack timeout
-    props.put(PropertyKeys.UNRESPONSIVE_MS, "300000"); //kill dead channel when no activity for 5 minutes    
-    return props;
+      settings.setMockHttp(false);
+      settings.setEventBatchSize(0); //send immediately
+      settings.setAckTimeoutMS(180000); //3 minute ack timeout
+      settings.setUnresponsiveMS(300000); //kill dead channel when no activity for 5 minutes
   }
     
     

--- a/src/test/java/com/splunk/cloudfwd/test/perf/OncePerSecondLongevityTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/OncePerSecondLongevityTest.java
@@ -50,8 +50,8 @@ public class OncePerSecondLongevityTest extends AbstractPerformanceTest {
     }
     
   @Override
-  protected void setProps(PropertiesFileHelper settings) {
-      super.setProps(settings);
+  protected void configureProps(PropertiesFileHelper settings) {
+      super.configureProps(settings);
     //simulate a non-sticky endpoint
       settings.setMockHttp(false);
       settings.setEventBatchSize(0); //send immediately

--- a/src/test/java/com/splunk/cloudfwd/test/util/AbstractConnectionTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/util/AbstractConnectionTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.splunk.cloudfwd.HecLoggerFactory;
+import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -21,7 +22,6 @@ import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.UnvalidatedByteBufferEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 /*
@@ -97,23 +97,22 @@ public abstract class AbstractConnectionTest {
   }
   
   protected Connection createAndConfigureConnection(){
-     Properties props = new Properties();
-    props.putAll(getTestProps());
-    props.putAll(getProps());
-    Connection connection = createConnection(callbacks, props);
-    if(null ==connection){
-        return null;
+    PropertiesFileHelper settings = getTestProps();
+    setProps(settings);
+    connection = createConnection(callbacks, settings);
+    if(null == connection){
+      return null;
     }
     connection.setLoggerFactory(new HecLoggerFactoryImpl());
     configureConnection(connection);
     return connection;
   }
   
-  protected Connection createConnection(ConnectionCallbacks c, Properties p){
+  protected Connection createConnection(ConnectionCallbacks c, PropertiesFileHelper settings){
       boolean didThrow = false;
       Connection conn = null;
       try{
-        conn = Connections.create(callbacks, p);
+        conn = Connections.create(callbacks, settings);
       }catch(Exception e){
           e.printStackTrace();
           didThrow = true;
@@ -300,8 +299,8 @@ public abstract class AbstractConnectionTest {
    *
    * @return
    */
-  protected Properties getProps() {
-    return new Properties(); //default behavior is no "hard coded" test-specific properties
+  protected void setProps(PropertiesFileHelper settings) {
+    //default behavior is no "hard coded" test-specific properties
   }
 
   /**
@@ -310,25 +309,18 @@ public abstract class AbstractConnectionTest {
    *
    * @return
    */
-  protected Properties getTestProps() {
-    Properties props = new Properties();
-    try (InputStream is = getClass().getResourceAsStream(
-            getTestPropertiesFileName())) {
-      if (null != is) {
-        props.load(is);
-      } else {
-        LOG.trace("No test_defaults.properties found on classpath");
-      }
-    } catch (IOException ex) {
-      LOG.error(ex.getMessage(), ex);
-    }
-    if (Boolean.parseBoolean(props.getProperty("enabled", "false"))) {
-      return props;
+  protected PropertiesFileHelper getTestProps() {
+
+    PropertiesFileHelper testSettings = PropertiesFileHelper.fromPropsFile(getTestPropertiesFileName());
+    if (testSettings.getTestPropertiesEnabled()) {
+      return testSettings;
     } else {
       LOG.warn("test.properties disabled, using cloudfwd.properties only");
-      return new Properties(); //ignore test.properties
+      return PropertiesFileHelper.fromPropsFile(getCloudfwdPropertiesFileName()); //ignore test.properties
     }
   }
+
+  private String getCloudfwdPropertiesFileName() { return "/cloudfwd.properties"; }
 
   /**
    * test can override this if a test requires its own .properties file to slap

--- a/src/test/java/com/splunk/cloudfwd/test/util/AbstractConnectionTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/util/AbstractConnectionTest.java
@@ -98,7 +98,7 @@ public abstract class AbstractConnectionTest {
   
   protected Connection createAndConfigureConnection(){
     PropertiesFileHelper settings = getTestProps();
-    setProps(settings);
+    configureProps(settings);
     connection = createConnection(callbacks, settings);
     if(null == connection){
       return null;
@@ -299,7 +299,7 @@ public abstract class AbstractConnectionTest {
    *
    * @return
    */
-  protected void setProps(PropertiesFileHelper settings) {
+  protected void configureProps(PropertiesFileHelper settings) {
     //default behavior is no "hard coded" test-specific properties
   }
 

--- a/src/test/resources/cloudfwd.properties
+++ b/src/test/resources/cloudfwd.properties
@@ -14,7 +14,7 @@
 
 ###### HEC Properties ######
 #HEC url with port (Multiple url's can be comma separated list)
-splunk_hec_url=https://inputs1.kinesis4.splunkcloud.com:8088
+url=https://inputs1.kinesis4.splunkcloud.com:8088
 #HEC token
 splunk_hec_token=3664A2C4-50B4-485E-86E0-C65D5A4B9232
 #Override hostname of machine sending data

--- a/src/test/resources/cloudfwd.properties
+++ b/src/test/resources/cloudfwd.properties
@@ -30,7 +30,7 @@ splunk_hec_sourcetype=
 ###### Cloudfwd Properties ######
 #Mock Splunk flag for test execution
 mock_http=false
-disableCertificateValidation=true
+disable_certificate_validation=true
 channels_per_dest=4
 max_total_channels=16
 max_unacked_per_channel=2
@@ -76,6 +76,6 @@ ssl_cert_content=
 ## Use custom SSL Certificate for hostnames that match the regex
 #ssl_cert_hostname_regex=^*.put.your.hostname.here$
 ssl_cert_hostname_regex=
-=
+
 #3 min preflight timeout
 preflight_timeout=180000

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -14,7 +14,7 @@
 
 ###### HEC Properties ######
 #HEC url with port (Multiple url's can be comma separated list)
-splunk_hec_url=https://127.0.0.1:8088
+url=https://127.0.0.1:8088
 #HEC token
 splunk_hec_token=
 #Override hostname of machine sending data
@@ -33,7 +33,7 @@ enabled=true
 enable_checkpoints=false
 #Mock Splunk flag for test execution
 mock_http=true
-disableCertificateValidation=true
+disable_certificate_validation=true
 channels_per_dest=4
 max_total_channels=8
 max_unacked_per_channel=10000


### PR DESCRIPTION
- Connections.create() now takes a ConnectionSettings object instead of a generic Java Properties object to populate Connection settings. The caller instantiates a ConnectionSettings object by calling PropertiesFileHelper.fromPropsFile('path/to/props/file'), and then uses the ConnectionSettings' setters to override properties with custom values, instead of calling put(). [PropertiesFileHelper inherits from ConnectionSettings]

- ConnectionSettings object has all Connection properties set upon it directly as instance variables, instead of containing a nested Properties object. This allows Jackson to perform mapping of properties in cloudfwd.properties and test.properties to attributes on the ConnectionSettings object, using annotations to map different property names like 'splunk_hec_token' to the instance variable 'token' and its associated getters/setters.

- Added getters and setters for each ConnectionSettings property, and moved validation to the setters instead of the getters. Calling a getter always returns the property value, unless is null, in which case it returns the default value. Calling a setter validates the passed in value, and replaces it with min/max/whatever allowed value if it fails validation.

- Connections now prints out ConnectionSettings properties on init() using LOG.info()

- The property 'splunk_hec_url' has correctly been renamed back to 'url'