### PR TITLE
Modify health polling to use fewer resources

### DIFF
--- a/src/main/java/com/splunk/cloudfwd/Connection.java
+++ b/src/main/java/com/splunk/cloudfwd/Connection.java
@@ -59,6 +59,7 @@ public interface Connection extends Closeable{
      * @return the callbacks
      */
     ConnectionCallbacks getCallbacks();
+    
 
     /**
      * @return the closed

--- a/src/main/java/com/splunk/cloudfwd/impl/http/HttpSender.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/HttpSender.java
@@ -33,18 +33,13 @@ import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 
-import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
-import java.util.Properties;
 import java.util.Set;
 //import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static com.splunk.cloudfwd.PropertyKeys.*;
-import com.splunk.cloudfwd.impl.util.LoadBalancer;
 import com.splunk.cloudfwd.impl.util.ThreadScheduler;
 import java.net.URISyntaxException;
-import java.util.logging.Level;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.utils.URIBuilder;
 

--- a/src/main/java/com/splunk/cloudfwd/impl/http/lifecycle/EventBatchHelper.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/lifecycle/EventBatchHelper.java
@@ -15,6 +15,7 @@
  */
 package com.splunk.cloudfwd.impl.http.lifecycle;
 
+import com.splunk.cloudfwd.EventBatch;
 import com.splunk.cloudfwd.LifecycleEvent;
 
 /**

--- a/src/main/java/com/splunk/cloudfwd/impl/sim/EventEndpoint.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/EventEndpoint.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 public class EventEndpoint extends ClosableDelayableResponder implements Endpoint {
 
   private static final Logger LOG = LoggerFactory.getLogger(EventEndpoint.class.getName());
-  private AcknowledgementEndpoint ackEndpoint;
+  protected AcknowledgementEndpoint ackEndpoint;
 
     public EventEndpoint() {
     }
@@ -55,7 +55,7 @@ public class EventEndpoint extends ClosableDelayableResponder implements Endpoin
     return ackEndpoint.nextAckId();
   }
 
-  private static HttpEntity nextAckRespEntity(final int ackId) {
+  protected static HttpEntity nextAckRespEntity(final int ackId) {
 
     return new AckIdRespEntity(ackId);
   }
@@ -86,7 +86,7 @@ public class EventEndpoint extends ClosableDelayableResponder implements Endpoin
     }
   }
 
-  private static class AckIdRespEntity extends CannedEntity {
+  protected static class AckIdRespEntity extends CannedEntity {
 
     public AckIdRespEntity(long ackId) {
       super("{\"ackId\":" + ackId + "}");

--- a/src/main/java/com/splunk/cloudfwd/impl/sim/errorgen/cookies/UpdateableCookieEndpoints.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/errorgen/cookies/UpdateableCookieEndpoints.java
@@ -74,7 +74,7 @@ public class UpdateableCookieEndpoints extends SimulatedHECEndpoints {
 
     @Override
     protected EventEndpoint createEventEndpoint() {
-        return new CookiedEventpoint();
+        return new CookiedEventpoint(ackEndpoint);
     }
 
     @Override
@@ -96,6 +96,10 @@ public class UpdateableCookieEndpoints extends SimulatedHECEndpoints {
     }
 
     class CookiedEventpoint extends EventEndpoint {
+        public CookiedEventpoint(AcknowledgementEndpoint ackEndpoint) {
+            this.ackEndpoint = ackEndpoint;
+            //ackEndpoint.start();
+        }
 
         @Override
         public void post(HttpPostable events, FutureCallback<HttpResponse> cb) {

--- a/src/main/java/com/splunk/cloudfwd/impl/sim/errorgen/unhealthy/TriggerableUnhealthyEndpoints.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/errorgen/unhealthy/TriggerableUnhealthyEndpoints.java
@@ -15,7 +15,10 @@
  */
 package com.splunk.cloudfwd.impl.sim.errorgen.unhealthy;
 
+import com.splunk.cloudfwd.impl.http.HttpPostable;
 import com.splunk.cloudfwd.impl.http.httpascync.HttpCallbacksAbstract;
+import com.splunk.cloudfwd.impl.sim.AcknowledgementEndpoint;
+import com.splunk.cloudfwd.impl.sim.EventEndpoint;
 import com.splunk.cloudfwd.impl.sim.HealthEndpoint;
 import com.splunk.cloudfwd.impl.sim.SimulatedHECEndpoints;
 import org.apache.http.HttpResponse;
@@ -37,6 +40,11 @@ public class TriggerableUnhealthyEndpoints extends SimulatedHECEndpoints {
     return new TriggerableHealthEndpoint();
   }
 
+  @Override
+  protected EventEndpoint createEventEndpoint() {
+    return new TriggerableEventEndpoint(ackEndpoint);
+  }
+
   private static class TriggerableHealthEndpoint extends HealthEndpoint {
 
     @Override
@@ -55,5 +63,32 @@ public class TriggerableUnhealthyEndpoints extends SimulatedHECEndpoints {
 
     }
 
+  }
+
+  private static class TriggerableEventEndpoint extends EventEndpoint {
+    public TriggerableEventEndpoint(AcknowledgementEndpoint ackEndpoint) {
+      this.ackEndpoint = ackEndpoint;
+      //ackEndpoint.start();
+    }
+    
+    @Override
+    public void post(HttpPostable events, FutureCallback<HttpResponse> cb) {
+      Runnable respond;
+      if (healthy) {
+        respond = () -> {
+          cb.completed(new EventPostResponse(
+                  new AckIdRespEntity(nextAckId())
+          ));
+        };
+      } else {
+        respond = () -> {
+          ((HttpCallbacksAbstract) cb).completed(
+                  "Simulated Indexer unhealthy queue is busy.",
+                  503);
+        };
+      }
+      //return a single response with a delay uniformly distributed between  [0,5] ms
+      delayResponse(respond);
+    }
   }
 }

--- a/src/main/java/com/splunk/cloudfwd/impl/util/PropertiesFileHelper.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/PropertiesFileHelper.java
@@ -65,8 +65,10 @@ public class PropertiesFileHelper extends ConnectionSettings {
         try {
             // this is to support the creation of channels for socket addresses that are not resolvable
             // so that they can get decomissioned and recreated at a later time, in case DNS recovers
-            if (s.getAddress() == null) {
-                return createSender(s.toString(), s.getHostName() + ":" + s.getPort());
+            if (s.isUnresolved()) { 
+                //since the hostname could not be resolved to an IP address, we cannot construct the URL
+                //using the resolved hostAddr as we do below. 
+                return createSender("https://"+s.toString(), s.getHostName() + ":" + s.getPort());
             }            
             //URLS for channel must be based on IP address not hostname since we
             //have many-to-one relationship between IP address and hostname via DNS records

--- a/src/test/java/com/splunk/cloudfwd/test/mock/UnhealthyEndpointTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/UnhealthyEndpointTest.java
@@ -115,7 +115,9 @@ public final class UnhealthyEndpointTest extends AbstractConnectionTest {
         //MAKE UNhealthy then send a second message
         TriggerableUnhealthyEndpoints.healthy = false;
         LOG.trace("waiting to detect unhealthy channel");
-        Thread.sleep(sleepTime); //make sure health poll becomes unhealthy (poll has interval so we must wait)
+        connection.send(getTimestampedRawEvent(2));
+        Thread.sleep(sleepTime); //wait for event post to return so health gets recorded as unhealthy. 
+        // At this point, we should have begun health polling since an event post failed, and HecHealth should be flipped to unhealthy.
         HecHealth h = connection.getHealth().get(0);
         LOG.info("{}", h);
         Assert.assertTrue("Expected unhealty channel but got: " + h, !h.isHealthy());
@@ -124,7 +126,7 @@ public final class UnhealthyEndpointTest extends AbstractConnectionTest {
         new Thread(() -> {
           long start = System.currentTimeMillis();
           try {
-            connection.send(getTimestampedRawEvent(2));
+            connection.send(getTimestampedRawEvent(3));
           } catch (HecConnectionTimeoutException ex) {
             LOG.error(ex.getMessage(), ex);
             Assert.fail();
@@ -140,7 +142,7 @@ public final class UnhealthyEndpointTest extends AbstractConnectionTest {
         //...which will cause acknowledged to be invoked again, but then count will be 2 so test will end.
          h = connection.getHealth().get(0);
         LOG.info("{}", h);
-        Assert.assertTrue("Expected healty channel but got: " + h, h.isHealthy());      
+        Assert.assertTrue("Expected healthy channel but got: " + h, h.isHealthy());      
 
       } catch (InterruptedException ex) {
         LOG.error(ex.getMessage(), ex);

--- a/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
@@ -42,7 +42,7 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
         cliProperties.put(MAX_MEMORY_MB_KEY, "500"); //500MB
         cliProperties.put(NUM_SENDERS_KEY, "1"); //128 senders
         cliProperties.put(PropertyKeys.TOKEN, null); // will use token in cloudfwd.properties by default
-        cliProperties.put(PropertyKeys.COLLECTOR_URI, "https://06a45d10-0e0a-46d1-ae8c-859a87c2aebe.d0cf7026-4c88-465a-8d27-d39169b7a394.com:12345"); // will use token in cloudfwd.properties by default
+        cliProperties.put(PropertyKeys.COLLECTOR_URI, null); // will use token in cloudfwd.properties by default
     }
     
     private int numSenderThreads = 128;

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -27,7 +27,7 @@ limitations under the License.
   </Appenders> 
   <Loggers>
     <Root level="info">
-      <AppenderRef ref="Console"/>
+      <AppenderRef ref="VerifyLogFile"/>
     </Root>
     <Logger name="org.apache.http" level="error">
       <AppenderRef ref="VerifyLogFile"/>


### PR DESCRIPTION
By @geoffhendrey 
Adjust health polling so that if the channel is currently healthy we will not perform the poll. So we should only execute polling after an event post fails. Then we will poll at the polling interval until the channel becomes healthy again.

* Fix bug where, when we allowed for creation of channels with hostnames that did not resolve, we were incorrectly ommitting "https" from the URL.
By @ecprokop 
* fix failing tests