### PR TITLE
Refactor PropertiesFileHelper to SenderFactory

### DIFF
--- a/src/main/java/com/splunk/cloudfwd/ConnectionSettings.java
+++ b/src/main/java/com/splunk/cloudfwd/ConnectionSettings.java
@@ -32,8 +32,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
-
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,6 +82,9 @@ public class ConnectionSettings {
 
     @JsonProperty("mock_http")
     private Boolean mockHttp = false;
+
+    @JsonProperty("mock_force_url_map_to_one")
+    private Boolean mockForceUrlMapToOne;
 
     @JsonProperty("enabled")
     private Boolean testPropertiesEnabled;
@@ -142,14 +143,15 @@ public class ConnectionSettings {
     @JsonProperty("event_batch_flush_timeout_ms")
     private long eventBatchFlushTimeout = DEFAULT_EVENT_BATCH_FLUSH_TIMEOUT_MS;
 
-    public static PropertiesFileHelper fromPropsFile(String pathToFile) {
+    public static ConnectionSettings fromPropsFile(String pathToFile) {
         // use Jackson to populate this ConnectionSettings instance from file
         JavaPropsMapper mapper = new JavaPropsMapper();
         try {
             InputStream inputStream = ConnectionSettings.class.getResourceAsStream(pathToFile);
             if (inputStream != null) {
-                PropertiesFileHelper propertiesFileHelper = mapper.readValue(inputStream, PropertiesFileHelper.class);
-                return propertiesFileHelper;
+                ConnectionSettings connectionSettings = mapper.readValue(inputStream, ConnectionSettings.class);
+                
+                return connectionSettings;
             }
         } catch (IOException e) {
             throw new RuntimeException("Could not map Properties file to Java object - please check file path.", e);
@@ -277,6 +279,11 @@ public class ConnectionSettings {
     public String getMockHttpClassname() {
         return applyDefaultIfNull(this.mockHttpClassname, "com.splunk.cloudfwd.impl.sim.SimulatedHECEndpoints");
     }
+
+    public boolean isForcedUrlMapToSingleAddr() {
+        return applyDefaultIfNull(this.mockForceUrlMapToOne, false);
+    }
+
 
     public Endpoints getSimulatedEndpoints() {
         try {
@@ -500,6 +507,10 @@ public class ConnectionSettings {
 
     public void setMockHttpClassname(String endpoints) {
         this.mockHttpClassname = endpoints;
+    }
+
+    public void setMockForceUrlMapToOne(Boolean force) {
+        this.mockForceUrlMapToOne = force;
     }
     
     public void setPreFlightTimeoutMS(long timeoutMS) {

--- a/src/main/java/com/splunk/cloudfwd/impl/sim/ValidatePropsEndpoint.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/ValidatePropsEndpoint.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 public class ValidatePropsEndpoint extends SimulatedHECEndpoints {
 
-    public static List<URL> URLS; // set with PropertiesFileHelper.getUrls()
+    public static List<URL> URLS; // set with ConnectionSettings.getUrls()
     public static long ACK_TIMEOUT_MS;
     public static String TOKEN;
     private static Throwable fail = null;

--- a/src/main/java/com/splunk/cloudfwd/impl/util/HecChannel.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/HecChannel.java
@@ -81,8 +81,7 @@ public class HecChannel implements Closeable, LifecycleEventObserver {
     this.channelId = newChannelId();
     this.channelMetrics = new ChannelMetrics(c);
     this.channelMetrics.addObserver(this);
-    this.maxUnackedEvents = loadBalancer.getPropertiesFileHelper().
-            getMaxUnackedEventBatchPerChannel();
+    this.maxUnackedEvents = loadBalancer.getConnection().getSettings().getMaxUnackedEventBatchPerChannel();
     this.memoizedToString = this.channelId + "@" + sender.getBaseUrl();
     LOG.info("constructing channel: {}", memoizedToString);
             

--- a/src/main/java/com/splunk/cloudfwd/impl/util/IndexDiscoverer.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/IndexDiscoverer.java
@@ -27,6 +27,7 @@ import java.util.Observable;
 import java.util.Random;
 import java.util.concurrent.ConcurrentSkipListMap;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import org.slf4j.Logger;
 import com.splunk.cloudfwd.impl.ConnectionImpl;
@@ -44,19 +45,19 @@ public class IndexDiscoverer extends Observable {
   //InetSocketAddresses resolved. This means that equality for URL changes based on DNS host resolution
   //and would be changing over time
   //private Map<String, List<InetSocketAddress>> mappings;
-  private final PropertiesFileHelper propertiesFileHelper;// = new PropertiesFileHelper();
+  private final ConnectionSettings connectionSettings;// = new ConnectionSettings();
   private ConnectionImpl connection;
 
-  public IndexDiscoverer(PropertiesFileHelper f, ConnectionImpl c) {
+  public IndexDiscoverer(ConnectionSettings f, ConnectionImpl c) {
     this.LOG = c.getLogger(IndexDiscoverer.class.getName());
     this.connection = c;
-    this.propertiesFileHelper = f;
+    this.connectionSettings = f;
   }
   
 
   public synchronized List<InetSocketAddress> getAddrs(){
     // perform DNS lookup
-    Map<String, List<InetSocketAddress>> mappings = getInetAddressMap(propertiesFileHelper.getUrls());
+    Map<String, List<InetSocketAddress>> mappings = getInetAddressMap(connectionSettings.getUrls());
     List<InetSocketAddress> addrs = new ArrayList<>();
     for (List<InetSocketAddress> sockAddrs : mappings.values()) {
       addrs.addAll(sockAddrs);
@@ -143,7 +144,7 @@ public class IndexDiscoverer extends Observable {
 //  * called by IndexerDiscoveryScheduler
 //  */
 //  synchronized void discover(){
-//    update(getInetAddressMap(propertiesFileHelper.getUrls(),
+//    update(getInetAddressMap(settings.getUrls(),
 //        this.forceUrlMapToOne), mappings);
 //  }
 

--- a/src/main/java/com/splunk/cloudfwd/impl/util/LoadBalancer.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/LoadBalancer.java
@@ -65,8 +65,8 @@ public class LoadBalancer implements Closeable {
     public LoadBalancer(ConnectionImpl c) {
         this.LOG = c.getLogger(LoadBalancer.class.getName());
         this.connection = c;
-        this.channelsPerDestination = c.getPropertiesFileHelper().getChannelsPerDestination();
-        this.discoverer = new IndexDiscoverer(c.getPropertiesFileHelper(), c);
+        this.channelsPerDestination = c.getSettings().getChannelsPerDestination();
+        this.discoverer = new IndexDiscoverer(c.getSettings(), c);
         createChannels(discoverer.getAddrs());
         //Reaping will randomly remove a channel and replace it with a fresh one every so often. 
         //This insures that channels get spread across indexers, even when we are fronted by an ELB
@@ -150,7 +150,7 @@ public class LoadBalancer implements Closeable {
     private void setupReaper() {
         //One channel will be decomissioned each time the scheduler, below, fires. And there will be an interval of decomMS
         //between each channel that is decomissioned. We need to avoid "storm" of decomissioning many channels at once.
-        long decomMs = getPropertiesFileHelper().getChannelDecomMS();
+        long decomMs = this.connection.getSettings().getChannelDecomMS();
         if (decomMs > 0) {
             this.reaperTaskFuture  = ThreadScheduler.getSharedSchedulerInstance("channel_decom_scheduler").scheduleWithFixedDelay(() -> {
                 ArrayList<HecChannel> channels = (ArrayList) this.channels.values();
@@ -203,7 +203,7 @@ public class LoadBalancer implements Closeable {
     private void waitForOnePreflightSuccess(List<HecHealth> healths, List<Future<Void>> futures, 
             List<HecChannel> channelsList) {
         long startMS = System.currentTimeMillis();
-        long timeoutMS = getPropertiesFileHelper().getPreFlightTimeoutMS();
+        long timeoutMS = this.connection.getSettings().getPreFlightTimeoutMS();
         boolean preFlightPassed = false;
         while (!Thread.interrupted()) {
             int numFailed = 0;
@@ -264,7 +264,7 @@ public class LoadBalancer implements Closeable {
                     getMaxTotalChannels() + ")");
             return null;
         }
-        HttpSender sender = (getPropertiesFileHelper()).createSender(s);
+        HttpSender sender = (this.connection.getSenderFactory()).createSender(s);
 
         HecChannel channel = new HecChannel(this, sender, this.connection);
         channel.getChannelMetrics().addObserver(this.connection.getCheckpointManager());
@@ -367,7 +367,7 @@ public class LoadBalancer implements Closeable {
         if (!closed || forced) {
             this.connection.getCheckpointManager().registerEventBatch(events, forced);
         }
-        if(this.channels.size() > getPropertiesFileHelper().getMaxTotalChannels()){
+        if(this.channels.size() > this.connection.getSettings().getMaxTotalChannels()){
             LOG.warn("{} exceeded. There are currently: {}",  PropertyKeys.MAX_TOTAL_CHANNELS, channels.size());
         }
     }
@@ -569,15 +569,8 @@ public class LoadBalancer implements Closeable {
         return connection;
     }
 
-    /**
-     * @return the propertiesFileHelper
-     */
-    public PropertiesFileHelper getPropertiesFileHelper() {
-        return this.connection.getPropertiesFileHelper();
-    }
-
     private boolean isResendable(EventBatchImpl events) {
-         final int maxRetries = getPropertiesFileHelper().getMaxRetries();
+         final int maxRetries = this.connection.getSettings().getMaxRetries();
         if (events.getNumTries() > maxRetries) {
                               String msg = "Tried to send event id=" + events.
                               getId() + " " + events.getNumTries() + " times.  See property " + PropertyKeys.RETRIES;

--- a/src/main/java/com/splunk/cloudfwd/impl/util/TimeoutChecker.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/TimeoutChecker.java
@@ -60,7 +60,7 @@ public class TimeoutChecker implements EventTracker {
 
     private long getTimeoutMs() {
         //check for timeouts with a minimum frequency of 1 second
-        return connection.getPropertiesFileHelper().getAckTimeoutMS();
+        return connection.getSettings().getAckTimeoutMS();
     }
 
     //how often we should rip through the list and check for timeouts

--- a/src/test/java/com/splunk/cloudfwd/test/integration/AWSSourcetypeIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/AWSSourcetypeIT.java
@@ -15,7 +15,6 @@ package com.splunk.cloudfwd.test.integration;/*
  */
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.splunk.cloudfwd.*;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -194,7 +193,7 @@ public class AWSSourcetypeIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         super.configureProps(settings);
         settings.setToken(createTestToken(null));
     }

--- a/src/test/java/com/splunk/cloudfwd/test/integration/AbstractReconciliationTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/AbstractReconciliationTest.java
@@ -3,10 +3,10 @@ package com.splunk.cloudfwd.test.integration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.impl.http.HttpClientFactory;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.io.IOException;
 import java.util.*;
 
@@ -119,7 +119,7 @@ public abstract class AbstractReconciliationTest extends AbstractConnectionTest 
   }
 
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setMockHttp(false);
     settings.setEventBatchSize(16000);
     settings.setToken(createTestToken(getSourceType()));

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ByteBufferEventsToWrongEndpointTestIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ByteBufferEventsToWrongEndpointTestIT.java
@@ -16,10 +16,10 @@
 package com.splunk.cloudfwd.test.integration;
 
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.UnvalidatedByteBufferEvent;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import java.nio.ByteBuffer;
 import org.junit.Test;
@@ -30,7 +30,7 @@ import org.junit.Test;
  */
 public class ByteBufferEventsToWrongEndpointTestIT extends AbstractReconciliationTest{
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
       super.configureProps(settings);
       //intentionally direct text events to /events endpoint
       settings.setHecEndpointType(Connection.HecEndpoint.STRUCTURED_EVENTS_ENDPOINT);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionAcksDisabledIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionAcksDisabledIT.java
@@ -1,8 +1,8 @@
 package com.splunk.cloudfwd.test.integration;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -20,7 +20,7 @@ public class CreateConnectionAcksDisabledIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         super.configureProps(settings);
         settings.setToken(createTestToken(null, false));
         settings.setMaxTotalChannels(1);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionInvalidTokenIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionInvalidTokenIT.java
@@ -1,8 +1,8 @@
 package com.splunk.cloudfwd.test.integration;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -18,7 +18,7 @@ public class CreateConnectionInvalidTokenIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         super.configureProps(settings);
         settings.setToken("invalid_token");
     }

--- a/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionSomeUnknownHostsIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/CreateConnectionSomeUnknownHostsIT.java
@@ -1,9 +1,9 @@
 package com.splunk.cloudfwd.test.integration;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import java.util.Set;
 
@@ -30,7 +30,7 @@ public class CreateConnectionSomeUnknownHostsIT extends AbstractReconciliationTe
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         super.configureProps(settings);
         settings.setToken(createTestToken("__singleline"));
         settings.setUrls(unknownHost + ",https://localhost:8088");

--- a/src/test/java/com/splunk/cloudfwd/test/integration/OnlyOnePreflightPassesIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/OnlyOnePreflightPassesIT.java
@@ -1,13 +1,10 @@
 package com.splunk.cloudfwd.test.integration;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.PropertyKeys;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -31,7 +28,7 @@ public class OnlyOnePreflightPassesIT extends AbstractReconciliationTest {
     }
     
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setToken(createTestToken(null));
         settings.setUrls("https://127.0.0.1:8088,https://kinesis4.splunkcloud.com:8088");  //two endpoints. The kinesis4 endpoint exsits, but isn't HEC endpoint (it's search head)
         settings.setMockHttp(false);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/PeriodicEventBatchFlushIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/PeriodicEventBatchFlushIT.java
@@ -1,14 +1,12 @@
 package com.splunk.cloudfwd.test.integration;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.PropertyKeys;
 import com.splunk.cloudfwd.RawEvent;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -39,7 +37,7 @@ public class PeriodicEventBatchFlushIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         super.configureProps(settings);
         settings.setEventBatchFlushTimeout(2000);
         settings.setEventBatchSize(100000000); // big enough that we don't fill the batch

--- a/src/test/java/com/splunk/cloudfwd/test/integration/PreflightTimeoutIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/PreflightTimeoutIT.java
@@ -1,16 +1,12 @@
 package com.splunk.cloudfwd.test.integration;
 
-import com.splunk.cloudfwd.HecHealth;
-import com.splunk.cloudfwd.PropertyKeys;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CHANNEL_PREFLIGHT_TIMEOUT;
-import com.splunk.cloudfwd.error.HecNoValidChannelsException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Test;
 
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -23,7 +19,7 @@ public class PreflightTimeoutIT extends AbstractConnectionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setUrls("https://kinesis4.splunkcloud.com:8088"); // URL with HEC not enabled
         settings.setMockHttp(false);
         settings.setMaxRetries(3);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/SplunkEventFieldsIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/SplunkEventFieldsIT.java
@@ -1,7 +1,7 @@
 package com.splunk.cloudfwd.test.integration;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -17,7 +17,7 @@ public class SplunkEventFieldsIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         super.configureProps(settings);
         settings.setToken(createTestToken(null));
         settings.setMaxTotalChannels(1);

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ToggleTokenValidityIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ToggleTokenValidityIT.java
@@ -3,7 +3,6 @@ package com.splunk.cloudfwd.test.integration;
 import com.splunk.cloudfwd.*;
 import com.splunk.cloudfwd.error.HecNoValidChannelsException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -95,7 +94,7 @@ public class ToggleTokenValidityIT extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         super.configureProps(settings);
         settings.setToken(createTestToken("__singleline"));
         // we don't want to hit any ack timeouts because it's easier to make our callbacks not expect them

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostDisabledCertValidationIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostDisabledCertValidationIT.java
@@ -14,15 +14,13 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
  * limitations under the License.
  */
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
-
-import static com.splunk.cloudfwd.PropertyKeys.*;
 
 /**
  * This test attempts to connect to ELB configured with a splunkcloud.com cert by 
@@ -44,7 +42,7 @@ public class SslCertDoesNotMatchHostDisabledCertValidationIT extends AbstractCon
   }
   
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setUrls("https://kinesis1-indexers-229328170.us-east-1.elb.amazonaws.com:443");
     settings.setToken("DB22D948-5A1D-4E73-8626-0AB3143BEE47");
     settings.disableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertDoesNotMatchHostIT.java
@@ -14,8 +14,8 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
  * limitations under the License.
  */
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Test;
@@ -53,7 +53,7 @@ public class SslCertDoesNotMatchHostIT extends AbstractConnectionTest {
   }
   
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setUrls("https://kinesis1-indexers-229328170.us-east-1.elb.amazonaws.com:443");
     settings.setToken("DB22D948-5A1D-4E73-8626-0AB3143BEE47");
     settings.enableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialDisabledCertValidationIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialDisabledCertValidationIT.java
@@ -14,15 +14,13 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
  * limitations under the License.
  */
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
-
-import static com.splunk.cloudfwd.PropertyKeys.*;
 
 /**
  * Cloud>Trial is issued by a private Splunk certificate authority. For 
@@ -42,7 +40,7 @@ public class SslCertValidCloudTrialDisabledCertValidationIT extends AbstractConn
   }
   
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setUrls("https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
     settings.setToken("19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
     settings.disableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialFailByDefaultIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialFailByDefaultIT.java
@@ -14,10 +14,10 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
  * limitations under the License.
  */
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecNoValidChannelsException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Assert;
@@ -25,10 +25,7 @@ import org.junit.Test;
 
 import javax.net.ssl.SSLHandshakeException;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-
-import static com.splunk.cloudfwd.PropertyKeys.*;
 
 /**
  * Cloud>Trial is issued by a private Splunk certificate authority. For 
@@ -57,7 +54,7 @@ public class SslCertValidCloudTrialFailByDefaultIT extends AbstractConnectionTes
   }
   
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setUrls("https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
     settings.setToken("19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
     settings.enableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidCloudTrialIT.java
@@ -14,10 +14,10 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
  * limitations under the License.
  */
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class SslCertValidCloudTrialIT extends AbstractConnectionTest {
   }
   
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setUrls("https://input-prd-p-kzgcxv8qsv24.cloud.splunk.com:8088");
     settings.setToken("19FD13FC-8C67-4E5C-8C2B-E39E6CC76152");
     settings.enableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidIT.java
+++ b/src/test/java/com/splunk/cloudfwd/test/integration/ssl_cert_tests/SslCertValidIT.java
@@ -14,16 +14,14 @@ package com.splunk.cloudfwd.test.integration.ssl_cert_tests;/*
  * limitations under the License.
  */
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.Properties;
 
 /**
  * This test enables SSL Verification and attempts to instantiate connection
@@ -52,12 +50,12 @@ public class SslCertValidIT extends AbstractConnectionTest {
   }
   
   @Override
-  protected PropertiesFileHelper getTestProps() {
-    return new PropertiesFileHelper();  
+  protected ConnectionSettings getTestProps() {
+    return new ConnectionSettings();  
   }
   
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setUrls("https://http-inputs-kinesis1.splunkcloud.com:443");
     settings.setToken("DB22D948-5A1D-4E73-8626-0AB3143BEE47");
     settings.enableCertValidation();

--- a/src/test/java/com/splunk/cloudfwd/test/mock/AbstractMutabilityTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/AbstractMutabilityTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 
 import java.util.concurrent.TimeUnit;
@@ -24,7 +24,7 @@ public abstract class AbstractMutabilityTest extends AbstractConnectionTest {
     }
 
     @Override
-    abstract protected void configureProps(PropertiesFileHelper settings);
+    abstract protected void configureProps(ConnectionSettings settings);
 
     protected void sendSomeEvents(int numEvents) throws InterruptedException, HecConnectionTimeoutException {
         LOG.trace(

--- a/src/test/java/com/splunk/cloudfwd/test/mock/AcknowledgementTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/AcknowledgementTimeoutTest.java
@@ -14,13 +14,13 @@ package com.splunk.cloudfwd.test.mock;/*
  * limitations under the License.
  */
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.EventBatch;
 import com.splunk.cloudfwd.error.HecAcknowledgmentTimeoutException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints;
 import org.junit.After;
 import org.junit.Assert;
@@ -60,8 +60,8 @@ public class AcknowledgementTimeoutTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
-        // props.put(PropertiesFileHelper.MOCK_HTTP_KEY, "true");
+    protected void configureProps(ConnectionSettings settings) {
+        // props.put(ConnectionSettings.MOCK_HTTP_KEY, "true");
         //simulate a slow endpoint
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
         if (SlowEndpoints.sleep > 10000) {

--- a/src/test/java/com/splunk/cloudfwd/test/mock/BatchedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/BatchedVolumeTest.java
@@ -15,10 +15,10 @@ package com.splunk.cloudfwd.test.mock;/*
  */
 
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import java.util.concurrent.TimeoutException;
 
@@ -34,7 +34,7 @@ public class BatchedVolumeTest extends AbstractConnectionTest {
   }
   
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
       settings.setAckTimeoutMS(1000000);
       settings.setUnresponsiveMS(-1); //no dead channel detection
   }
@@ -84,7 +84,7 @@ public class BatchedVolumeTest extends AbstractConnectionTest {
   @Override
   protected Properties getProps() {
     Properties props = new Properties();
-    props.put(PropertiesFileHelper.MOCK_HTTP_KEY, "true");
+    props.put(ConnectionSettings.MOCK_HTTP_KEY, "true");
     return props;
   }
 */

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ByteBufferEventTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ByteBufferEventTest.java
@@ -1,11 +1,11 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.UnvalidatedByteBufferEvent;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.nio.ByteBuffer;
 import org.junit.Test;
 
@@ -42,7 +42,7 @@ public class ByteBufferEventTest extends AbstractConnectionTest {
   }
 
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     //default behavior is no "hard coded" test-specific properties
     settings.setEventBatchSize(16000);
     settings.setMockHttp(true); //no dead channel detection

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ChangeEndpointWhileAccumulatingBatch.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ChangeEndpointWhileAccumulatingBatch.java
@@ -16,13 +16,11 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Connection;
-import com.splunk.cloudfwd.PropertyKeys;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.WRONG_EVENT_FORMAT_FOR_ENDPOINT;
 
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import java.util.Properties;
 import org.junit.Test;
 
 /**
@@ -33,7 +31,7 @@ import org.junit.Test;
  */
 public class ChangeEndpointWhileAccumulatingBatch extends AbstractConnectionTest{
 
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setEventBatchSize(1024*1024);
   }
     

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CloseNowTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CloseNowTest.java
@@ -1,13 +1,10 @@
 package com.splunk.cloudfwd.test.mock;
 
-import com.splunk.cloudfwd.PropertyKeys;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Test;
-
-import java.util.Properties;
 
 /**
  * Created by eprokop on 11/8/17.
@@ -19,7 +16,7 @@ public class CloseNowTest extends AbstractConnectionTest {
     }
     
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttp(true);
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionMutabilityTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionMutabilityTest.java
@@ -7,7 +7,6 @@ import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.impl.ConnectionImpl;
 import com.splunk.cloudfwd.impl.sim.ValidatePropsEndpoint;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -133,7 +132,7 @@ public class ConnectionMutabilityTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setAckTimeoutMS(1000000);
         settings.setUnresponsiveMS(-1); //no dead channel detection
         settings.setMockHttp(true);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionTimeoutTest.java
@@ -1,9 +1,9 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,7 +34,7 @@ public class ConnectionTimeoutTest extends AbstractConnectionTest {
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionTimeoutTest.class.getName());
 
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     //A realistic value of BLOCKING_TIMEOUT_MS would be 1 or more MINUTES, but let's not
     //make this test run too slowly. The point is, we want to SEE the HecConnectionTimeout
     //happen repeatedly, until the message goes through

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionNoRouteToHost.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionNoRouteToHost.java
@@ -1,15 +1,10 @@
 package com.splunk.cloudfwd.test.mock;
 
-import com.splunk.cloudfwd.LifecycleEvent;
-import com.splunk.cloudfwd.PropertyKeys;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
-import com.splunk.cloudfwd.error.HecServerErrorResponseException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.integration.AbstractReconciliationTest;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Properties;
 
 /**
  * Created by eprokop on 10/9/17.
@@ -22,7 +17,7 @@ public class CreateConnectionNoRouteToHost extends AbstractReconciliationTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttp(true);
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.NoRouteToHostEndpoints");
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionUnknownHostTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CreateConnectionUnknownHostTest.java
@@ -1,7 +1,7 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 
 /**
  * Scenario: Unknown host provided (no "good" URLs)
@@ -11,7 +11,7 @@ import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
  */
 public class CreateConnectionUnknownHostTest extends ExceptionConnInstantiationTest {
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setUrls("https://foobarunknownhostbaz:8088");
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unknownhost.UnknownHostEndpoints");
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/DeadChannelTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/DeadChannelTest.java
@@ -1,11 +1,11 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecChannelDeathException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeoutException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,7 +46,7 @@ public class DeadChannelTest extends AbstractConnectionTest {
     }
 
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setMockHttp(true);
     settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.ackslost.LossyEndpoints");
     settings.setUnresponsiveMS(4000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersAllDownTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersAllDownTest.java
@@ -1,12 +1,12 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.ConnectionCallbacks;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,7 +29,7 @@ public class DownIndexersAllDownTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.DownIndexerEndpoints");
         settings.setMaxTotalChannels(4);
         settings.setBlockingTimeoutMS(10000);
@@ -43,7 +43,7 @@ public class DownIndexersAllDownTest extends AbstractConnectionTest {
     private void createConnection() {
         this.callbacks = getCallbacks();
 
-        PropertiesFileHelper settings = getTestProps();
+        ConnectionSettings settings = getTestProps();
         configureProps(settings);
         connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersRollingRestartTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/DownIndexersRollingRestartTest.java
@@ -1,13 +1,12 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.ConnectionCallbacks;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.impl.sim.errorgen.indexer.RollingRestartEndpoints;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 
 /**
@@ -25,7 +24,7 @@ public class DownIndexersRollingRestartTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.RollingRestartEndpoints");
 
         // mocking 4 indexers with 1 channel each
@@ -48,7 +47,7 @@ public class DownIndexersRollingRestartTest extends AbstractConnectionTest {
     private void createConnection() {
         this.callbacks = getCallbacks();
 
-        PropertiesFileHelper settings = this.getTestProps();
+        ConnectionSettings settings = this.getTestProps();
         this.configureProps(settings);
         this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ExceptionConnInstantiationTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ExceptionConnInstantiationTest.java
@@ -1,9 +1,8 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
-import java.net.MalformedURLException;
 import org.junit.Test;
 
 /*
@@ -34,7 +33,7 @@ public class ExceptionConnInstantiationTest extends AbstractConnectionTest{
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setUrls("floort");
     }
     

--- a/src/test/java/com/splunk/cloudfwd/test/mock/GatewayTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/GatewayTimeoutTest.java
@@ -1,11 +1,11 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
 /**
@@ -19,7 +19,7 @@ public class GatewayTimeoutTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostGatewayTimeoutEndpoints");
         settings.setBlockingTimeoutMS(5000);
         settings.setAckTimeoutMS(500000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/HecEndpointEventTypeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/HecEndpointEventTypeTest.java
@@ -15,9 +15,9 @@ package com.splunk.cloudfwd.test.mock;/*
  */
 
 import com.splunk.cloudfwd.Connection.HecEndpoint;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +36,7 @@ public class HecEndpointEventTypeTest extends AbstractConnectionTest {
 
  
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setMockHttp(true);
   }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadyAckdTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadyAckdTest.java
@@ -1,8 +1,8 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class IllegalStateAlreadyAckdTest extends IllegalStateAlreadySentTest{
   
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttp(true);
         settings.setEventBatchSize(0); //make sure no batching
         settings.setMaxTotalChannels(1); //so we insure we resend on same channel

--- a/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadySentTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/IllegalStateAlreadySentTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,7 +33,7 @@ public class IllegalStateAlreadySentTest extends AbstractConnectionTest {
   private HecConnectionStateException.Type expectedExType;
 
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setMockHttp(true);
     settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
     settings.setEventBatchSize(0);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/MaxRetriesTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/MaxRetriesTest.java
@@ -1,11 +1,11 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
 import com.splunk.cloudfwd.error.HecChannelDeathException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,7 +36,7 @@ public class MaxRetriesTest extends AbstractConnectionTest {
   private static final Logger LOG = LoggerFactory.getLogger(MaxRetriesTest.class.getName());
 
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     //A realistic value of BLOCKING_TIMEOUT_MS would be 1 or more MINUTES, but let's not
     //make this test run too slowly. The point is, we want to SEE the HecConnectionTimeout
     //happen repeatedly, until the message goes through

--- a/src/test/java/com/splunk/cloudfwd/test/mock/NonBatchedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/NonBatchedVolumeTest.java
@@ -1,8 +1,8 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
@@ -38,7 +38,7 @@ public class NonBatchedVolumeTest extends AbstractConnectionTest {
 
 
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     //settings.setMockHttp(true);
   }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdTest.java
@@ -1,9 +1,9 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.ConnectionCallbacks;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.EventBatch;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 
@@ -56,7 +56,7 @@ public class OutOfOrderAckIdTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDEndpoints");
         settings.setBlockingTimeoutMS(30000);
         settings.setUnresponsiveMS(-1); //no dead channel detection
@@ -71,7 +71,7 @@ public class OutOfOrderAckIdTest extends AbstractConnectionTest {
     protected void createConnection() {
         this.callbacks = getCallbacks();
 
-        PropertiesFileHelper settings = getTestProps();
+        ConnectionSettings settings = getTestProps();
         configureProps(settings);
         this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdWithFailTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdWithFailTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDFailEndpoints;
@@ -92,7 +92,7 @@ public class OutOfOrderAckIdWithFailTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDFailEndpoints");
         settings.setBlockingTimeoutMS(30000);
         settings.setUnresponsiveMS(-1); //no dead channel detection

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderIdTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderIdTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.EventBatch;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class OutOfOrderIdTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setCheckpointEnabled(false);
     }
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/PropertiesConfigurationTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/PropertiesConfigurationTest.java
@@ -54,7 +54,7 @@ public class PropertiesConfigurationTest extends AbstractConnectionTest {
     // PropertiesHelper Configuration Tests
     @Test
     public void testPropertiesHelperWithOverrides() throws MalformedURLException {
-        // Need connection object to pass into PropertiesFileHelper constructor for failed() callback
+        // Need connection object to pass into ConnectionSettings constructor for failed() callback
         Properties overrides = new Properties();
         overrides.put(TOKEN, "foo-token");
         overrides.put(COLLECTOR_URI, "https://inputs1.kinesis1.foo.com:8088");
@@ -74,7 +74,7 @@ public class PropertiesConfigurationTest extends AbstractConnectionTest {
 
     @Test
     public void testPropertiesHelperWithoutOverrides() throws MalformedURLException {
-        // Need connection object to pass into PropertiesFileHelper constructor for failed() callback
+        // Need connection object to pass into ConnectionSettings constructor for failed() callback
         Properties overrides = new Properties();
         //can't make assumptions about what's in cloudfwd.properties
 //        

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ResendOnCatchingRuntimExceptionTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ResendOnCatchingRuntimExceptionTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.impl.sim.errorgen.runtimeexceptions.ExceptionsEndpoint;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class ResendOnCatchingRuntimExceptionTest extends AbstractConnectionTest {
 
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setMockHttp(true);
     settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.runtimeexceptions.ExceptionsEndpoint");
     settings.setEventBatchSize(0); //make sure no batching

--- a/src/test/java/com/splunk/cloudfwd/test/mock/SessionCookiesTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/SessionCookiesTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.impl.sim.errorgen.cookies.UpdateableCookieEndpoints;
 import com.splunk.cloudfwd.impl.util.HecHealthImpl;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -55,7 +55,7 @@ public class SessionCookiesTest extends AbstractConnectionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.cookies.UpdateableCookieEndpoints");
         settings.setMaxTotalChannels(1);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/SlideHighwaterOnFailTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/SlideHighwaterOnFailTest.java
@@ -1,9 +1,9 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecChannelDeathException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 
@@ -23,7 +23,7 @@ public class SlideHighwaterOnFailTest extends AbstractConnectionTest {
     private static final Logger LOG = LoggerFactory.getLogger(SlideHighwaterOnFailTest.class.getName());
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
       Properties props = new Properties();
       //A realistic value of BLOCKING_TIMEOUT_MS would be 1 or more MINUTES, but let's not
       //make this test run too slowly. The point is, we want to SEE the HecConnectionTimeout

--- a/src/test/java/com/splunk/cloudfwd/test/mock/SuperSimpleExample.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/SuperSimpleExample.java
@@ -1,13 +1,7 @@
 package com.splunk.cloudfwd.test.mock;
 
-import com.splunk.cloudfwd.Connection;
-import com.splunk.cloudfwd.ConnectionCallbacks;
-import com.splunk.cloudfwd.Connections;
-import com.splunk.cloudfwd.EventBatch;
-import com.splunk.cloudfwd.RawEvent;
-import com.splunk.cloudfwd.EventWithMetadata;
+import com.splunk.cloudfwd.*;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.text.SimpleDateFormat;
@@ -75,7 +69,7 @@ public class SuperSimpleExample {
     }; //end callbacks
 
     //overide defaults in cloudfwd.properties
-    PropertiesFileHelper customization = PropertiesFileHelper.fromPropsFile("/cloudfwd.properties");
+    ConnectionSettings customization = ConnectionSettings.fromPropsFile("/cloudfwd.properties");
     customization.setUrls("https://127.0.0.1:8088");
     customization.setToken("ad9017fd-4adb-4545-9f7a-62a8d28ba7b3");
     customization.setUnresponsiveMS(100000);//100 sec - Kill unresponsive channel

--- a/src/test/java/com/splunk/cloudfwd/test/mock/UnhealthyEndpointTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/UnhealthyEndpointTest.java
@@ -1,12 +1,12 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.EventBatch;
 import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.TriggerableUnhealthyEndpoints;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
@@ -49,8 +49,8 @@ public final class UnhealthyEndpointTest extends AbstractConnectionTest {
   }
 
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
-    //props.put(PropertiesFileHelper.MOCK_HTTP_KEY, "true");
+  protected void configureProps(ConnectionSettings settings) {
+    //props.put(ConnectionSettings.MOCK_HTTP_KEY, "true");
     //simulate a non-sticky endpoint
     settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.TriggerableUnhealthyEndpoints");
     settings.setMaxTotalChannels(1);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/UnvalidatedBytesTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/UnvalidatedBytesTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock;
 
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
 /*
@@ -46,7 +46,7 @@ public class UnvalidatedBytesTest extends AbstractConnectionTest {
     sendEvents();
   }
 
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     settings.setEventBatchSize(16000);
     //settings.setMockHttp(false);
     super.eventType = Event.Type.UNKNOWN;

--- a/src/test/java/com/splunk/cloudfwd/test/mock/UrlProtocolTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/UrlProtocolTest.java
@@ -1,7 +1,7 @@
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 
 import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CONFIGURATION_EXCEPTION;
 
@@ -24,7 +24,7 @@ import static com.splunk.cloudfwd.error.HecConnectionStateException.Type.CONFIGU
 
 public class UrlProtocolTest extends ExceptionConnInstantiationTest {
      @Override
-     protected void configureProps(PropertiesFileHelper settings) {
+     protected void configureProps(ConnectionSettings settings) {
          settings.setUrls("http://foo.com"); //http is not supported protocol. Must be https
     }
     

--- a/src/test/java/com/splunk/cloudfwd/test/mock/WatchdogChannelKillerTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/WatchdogChannelKillerTest.java
@@ -15,10 +15,10 @@
  */
 package com.splunk.cloudfwd.test.mock;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecAcknowledgmentTimeoutException;
 import com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import java.util.List;
@@ -38,7 +38,7 @@ import org.junit.Test;
 public class WatchdogChannelKillerTest extends AbstractConnectionTest {
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttp(true);
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
         settings.setEventBatchSize(0); //make sure no batching

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/AbstractHealthCheckTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/AbstractHealthCheckTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock.health_check_tests;
 
 import com.splunk.cloudfwd.ConnectionCallbacks;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 
@@ -30,7 +30,7 @@ public class AbstractHealthCheckTest extends AbstractConnectionTest {
     // Need to separate this logic out of setUp() so that each Test
     // can use different simulated endpoints
     protected void createConnection(LifecycleEvent.Type problemType) {
-        PropertiesFileHelper settings = this.getTestProps();
+        ConnectionSettings settings = this.getTestProps();
         configureProps(settings);
         boolean gotException = false;
         try{

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckAcksDisabledTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckAcksDisabledTest.java
@@ -1,7 +1,7 @@
 package com.splunk.cloudfwd.test.mock.health_check_tests;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +17,7 @@ public class HealthCheckAcksDisabledTest extends AbstractHealthCheckTest {
     private static final Logger LOG = LoggerFactory.getLogger(HealthCheckAcksDisabledTest.class.getName());
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.AckDisabledEndpoints");
         settings.setBlockingTimeoutMS(3000);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInDetentionTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInDetentionTest.java
@@ -1,8 +1,8 @@
 package com.splunk.cloudfwd.test.mock.health_check_tests;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +16,7 @@ public class HealthCheckInDetentionTest extends AbstractHealthCheckTest {
     private static final Logger LOG = LoggerFactory.getLogger(HealthCheckInDetentionTest.class.getName());
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.InDetentionEndpoints");
         settings.setBlockingTimeoutMS(3000);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidAuth.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidAuth.java
@@ -1,7 +1,7 @@
 package com.splunk.cloudfwd.test.mock.health_check_tests;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
 import java.util.concurrent.TimeoutException;
@@ -14,7 +14,7 @@ import static com.splunk.cloudfwd.LifecycleEvent.Type.INVALID_AUTH;
 public class HealthCheckInvalidAuth extends AbstractHealthCheckTest {
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidAuthEndpoints");
         settings.setBlockingTimeoutMS(3000);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidTokenTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/health_check_tests/HealthCheckInvalidTokenTest.java
@@ -1,7 +1,7 @@
 package com.splunk.cloudfwd.test.mock.health_check_tests;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 
 import java.util.concurrent.TimeoutException;
@@ -14,7 +14,7 @@ import static com.splunk.cloudfwd.LifecycleEvent.Type.INVALID_TOKEN;
 public class HealthCheckInvalidTokenTest extends AbstractHealthCheckTest {
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidTokenEndpoints");
         settings.setBlockingTimeoutMS(3000);
     }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/AbstractHecServerErrorResponseTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/AbstractHecServerErrorResponseTest.java
@@ -4,7 +4,6 @@ import com.splunk.cloudfwd.*;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,14 +64,14 @@ public abstract class AbstractHecServerErrorResponseTest extends AbstractConnect
     // Need to separate this logic out of setUp() so that each Test
     // can use different simulated endpoints
     protected void createConnection() {
-        PropertiesFileHelper settings = this.getTestProps();
+        ConnectionSettings settings = this.getTestProps();
         configureProps(settings);
         connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);
     }
 
     protected void createConnection(LifecycleEvent.Type problemType) {
-        PropertiesFileHelper settings = this.getTestProps();
+        ConnectionSettings settings = this.getTestProps();
         this.configureProps(settings);
         boolean gotException = false;
         try{

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseAcksDisabledTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseAcksDisabledTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock.hec_server_error_response_tests;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +41,7 @@ public class HecServerErrorResponseAcksDisabledTest extends AbstractHecServerErr
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.AckDisabledEndpoints");
         settings.setAckTimeoutMS(500000); //in this case we expect to see HecConnectionTimeoutException
         settings.setBlockingTimeoutMS(5000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKAndExpectAckTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKAndExpectAckTimeoutTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock.hec_server_error_response_tests;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecAcknowledgmentTimeoutException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +53,7 @@ public class HecServerErrorResponseIndexerBusyButHealthCheckOKAndExpectAckTimeou
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostIndexerBusyEndpoints");
         settings.setAckTimeoutMS(2000); //in this case we excpect to see HecConnectionTimeoutException
         settings.setBlockingTimeoutMS(5000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock.hec_server_error_response_tests;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.error.HecMaxRetriesException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +51,7 @@ public class HecServerErrorResponseIndexerBusyButHealthCheckOKTest extends Abstr
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostIndexerBusyEndpoints");
         settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
         settings.setBlockingTimeoutMS(5000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidEventNumber.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidEventNumber.java
@@ -1,11 +1,11 @@
 package com.splunk.cloudfwd.test.mock.hec_server_error_response_tests;
 
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -58,7 +58,7 @@ public class HecServerErrorResponseInvalidEventNumber extends AbstractHecServerE
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.invalidvent.InvalidEventEndpoint");
         settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
         settings.setBlockingTimeoutMS(5000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidTokenTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseInvalidTokenTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock.hec_server_error_response_tests;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +39,7 @@ public class HecServerErrorResponseInvalidTokenTest extends AbstractHecServerErr
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.splunkcheckfailure.InvalidTokenEndpoints");
         settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
         settings.setBlockingTimeoutMS(5000);

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseNoAckIdEvent.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseNoAckIdEvent.java
@@ -1,9 +1,9 @@
 package com.splunk.cloudfwd.test.mock.hec_server_error_response_tests;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +50,7 @@ public class HecServerErrorResponseNoAckIdEvent extends AbstractHecServerErrorRe
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         //in this case, the pre-flight check will pass, and we are simulating were we detect acks disabled on event post
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostNoAckIdEndpoints");
         settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException

--- a/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionAllTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionAllTest.java
@@ -1,10 +1,10 @@
 package com.splunk.cloudfwd.test.mock.in_detention_tests;
 
 import com.splunk.cloudfwd.ConnectionCallbacks;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Connections;
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,7 +32,7 @@ public class InDetentionAllTest extends AbstractInDetentionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.InDetentionEndpoints");
         settings.setBlockingTimeoutMS(30000);
         settings.setUnresponsiveMS(-1); //no dead channel detection
@@ -40,7 +40,7 @@ public class InDetentionAllTest extends AbstractInDetentionTest {
     }
 
     protected void createConnection(LifecycleEvent.Type problemType) {
-        PropertiesFileHelper settings = this.getTestProps();
+        ConnectionSettings settings = this.getTestProps();
         this.configureProps(settings);
         boolean gotException = false;
         try{

--- a/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionSomeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/in_detention_tests/InDetentionSomeTest.java
@@ -1,7 +1,6 @@
 package com.splunk.cloudfwd.test.mock.in_detention_tests;
 
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.*;
 import com.splunk.cloudfwd.error.HecServerErrorResponseException;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class InDetentionSomeTest extends AbstractInDetentionTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.indexer.SomeInDetentionEndpoints");
         settings.setBlockingTimeoutMS(30000);
         settings.setUnresponsiveMS(-1); //no dead channel detection
@@ -45,7 +44,7 @@ public class InDetentionSomeTest extends AbstractInDetentionTest {
     // Need to separate this logic out of setUp() so that each Test
     // can use different simulated endpoints
     protected void createConnection() {
-        PropertiesFileHelper settings = this.getTestProps();
+        ConnectionSettings settings = this.getTestProps();
         this.configureProps(settings);
         this.connection = Connections.create((ConnectionCallbacks) callbacks, settings);
         configureConnection(connection);

--- a/src/test/java/com/splunk/cloudfwd/test/perf/AbstractPerformanceTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/AbstractPerformanceTest.java
@@ -1,8 +1,8 @@
 package com.splunk.cloudfwd.test.perf;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.mock.ThroughputCalculatorCallback;
 import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
@@ -44,7 +44,7 @@ public abstract class AbstractPerformanceTest extends AbstractConnectionTest {
   }
   
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     //default behavior is no "hard coded" test-specific properties
     //the assumption here is that we are doing performance testing using cloudfwd.properties not test.properties
     settings.setTestPropertiesEnabled(false);

--- a/src/test/java/com/splunk/cloudfwd/test/perf/CloseNowInALoopTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/CloseNowInALoopTest.java
@@ -16,19 +16,17 @@
 package com.splunk.cloudfwd.test.perf;
 
 import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Connections;
-import com.splunk.cloudfwd.PropertyKeys;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -44,7 +42,7 @@ public class CloseNowInALoopTest {
     @Test
     public void loop() throws InterruptedException, ExecutionException{
         int numConnections = 100;
-        PropertiesFileHelper settings = new PropertiesFileHelper();
+        ConnectionSettings settings = new ConnectionSettings();
         settings.setUrls("https://127.0.0.1:8088");
         settings.setToken("7263336d-ac05-4db9-92c3-9536922d11b1");
         List<Connection> connections = Collections.synchronizedList(new ArrayList<>());

--- a/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
@@ -2,7 +2,6 @@ package com.splunk.cloudfwd.test.perf;
 
 import com.splunk.cloudfwd.*;
 import com.splunk.cloudfwd.impl.EventBatchImpl;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import com.splunk.cloudfwd.test.mock.ThroughputCalculatorCallback;
 import com.splunk.cloudfwd.test.util.BasicCallbacks;
 import org.junit.Assert;
@@ -141,7 +140,7 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
     }
 
     @Override
-    protected void configureProps(PropertiesFileHelper settings) {
+    protected void configureProps(ConnectionSettings settings) {
         super.configureProps(settings);
         String token = System.getProperty(PropertyKeys.TOKEN);
         String url = System.getProperty(PropertyKeys.COLLECTOR_URI);

--- a/src/test/java/com/splunk/cloudfwd/test/perf/OncePerSecondLongevityTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/OncePerSecondLongevityTest.java
@@ -1,7 +1,7 @@
 package com.splunk.cloudfwd.test.perf;
 
+import com.splunk.cloudfwd.ConnectionSettings;
 import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -50,7 +50,7 @@ public class OncePerSecondLongevityTest extends AbstractPerformanceTest {
     }
     
   @Override
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
       super.configureProps(settings);
     //simulate a non-sticky endpoint
       settings.setMockHttp(false);

--- a/src/test/java/com/splunk/cloudfwd/test/util/AbstractConnectionTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/util/AbstractConnectionTest.java
@@ -1,25 +1,17 @@
 package com.splunk.cloudfwd.test.util;
 
-import com.splunk.cloudfwd.Connection;
-import com.splunk.cloudfwd.Event;
-import com.splunk.cloudfwd.EventWithMetadata;
-import com.splunk.cloudfwd.RawEvent;
+import com.splunk.cloudfwd.*;
+
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.splunk.cloudfwd.HecLoggerFactory;
-import com.splunk.cloudfwd.impl.util.PropertiesFileHelper;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import com.splunk.cloudfwd.ConnectionCallbacks;
-import com.splunk.cloudfwd.Connections;
-import com.splunk.cloudfwd.HecHealth;
 import com.splunk.cloudfwd.error.HecConnectionTimeoutException;
-import com.splunk.cloudfwd.UnvalidatedByteBufferEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.nio.ByteBuffer;
@@ -58,7 +50,6 @@ public abstract class AbstractConnectionTest {
    * set enabled=false in test.properties to disable test.properties and
    * fallback on cloudfwd.properties
    */
-  public static final String KEY_ENABLE_TEST_PROPERTIES = "enabled";
   public static final String TEST_METHOD_GUID_KEY = "testMethodGUID";
 
   protected BasicCallbacks callbacks;
@@ -97,7 +88,7 @@ public abstract class AbstractConnectionTest {
   }
   
   protected Connection createAndConfigureConnection(){
-    PropertiesFileHelper settings = getTestProps();
+    ConnectionSettings settings = getTestProps();
     configureProps(settings);
     connection = createConnection(callbacks, settings);
     if(null == connection){
@@ -108,7 +99,7 @@ public abstract class AbstractConnectionTest {
     return connection;
   }
   
-  protected Connection createConnection(ConnectionCallbacks c, PropertiesFileHelper settings){
+  protected Connection createConnection(ConnectionCallbacks c, ConnectionSettings settings){
       boolean didThrow = false;
       Connection conn = null;
       try{
@@ -299,7 +290,7 @@ public abstract class AbstractConnectionTest {
    *
    * @return
    */
-  protected void configureProps(PropertiesFileHelper settings) {
+  protected void configureProps(ConnectionSettings settings) {
     //default behavior is no "hard coded" test-specific properties
   }
 
@@ -309,14 +300,13 @@ public abstract class AbstractConnectionTest {
    *
    * @return
    */
-  protected PropertiesFileHelper getTestProps() {
-
-    PropertiesFileHelper testSettings = PropertiesFileHelper.fromPropsFile(getTestPropertiesFileName());
+  protected ConnectionSettings getTestProps() {
+      ConnectionSettings testSettings = ConnectionSettings.fromPropsFile(getTestPropertiesFileName());
     if (testSettings.getTestPropertiesEnabled()) {
       return testSettings;
     } else {
       LOG.warn("test.properties disabled, using cloudfwd.properties only");
-      return PropertiesFileHelper.fromPropsFile(getCloudfwdPropertiesFileName()); //ignore test.properties
+      return ConnectionSettings.fromPropsFile(getCloudfwdPropertiesFileName()); //ignore test.properties
     }
   }
 


### PR DESCRIPTION
Rename PropertyFileHelper to SenderFactory and convert to not being subclass of ConnectionSettings (it will instead use a passed in instance of ConnectionSettings). 

All prior consumers of PropertyFileHelper will now use ConnectionSettings, as they do not need to instantiate a Sender but are just accessing the Connection properties. 

In addition, fixing bug where MaxTotalChannels was remaining -1 if setters were not explicitly called on that property (now, in the ConnectionImpl constructor, setMaxTotalChannels is set to validate and convert -1 to the max int value. 

Furthermore, adding ConnectionSettings to also be logged before the Connection is instantiated, as well as afterwards