### PR TITLE
Event lifecycle metrics

### DIFF
--- a/src/main/java/com/splunk/cloudfwd/EventBatch.java
+++ b/src/main/java/com/splunk/cloudfwd/EventBatch.java
@@ -96,5 +96,7 @@ public interface EventBatch extends HttpPostable {
      * @return the sendExceptions
      */
     List<Exception> getExceptions();
+    
+  LifecycleMetrics getLifecycleMetrics();
       
 }

--- a/src/main/java/com/splunk/cloudfwd/LifecycleMetrics.java
+++ b/src/main/java/com/splunk/cloudfwd/LifecycleMetrics.java
@@ -1,0 +1,104 @@
+package com.splunk.cloudfwd;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by eprokop on 12/21/17.
+ */
+public class LifecycleMetrics {
+    public static final String CREATION_TIMESTAMP = "creation_timestamp"; // time the event batch was constructed 
+    public static final String START_LB_SPIN_TIMESTAMP = "start_lb_spin_timestamp"; // time the event batch entered the load balancer
+    public static final String POST_SENT_TIMESTAMP = "post_sent_timestamp"; // time the event batch post request was sent to Splunk
+    public static final String POST_RESPONSE_TIMESTAMP= "post_repsonse_timestamp"; // time the event batch post request received a response
+    public static final String ACKED_TIMESTAMP = "acked_timestamp"; // time the event batch was acknowledged
+    public static final String FAILED_TIMESTAMP = "failed_timestamp"; // time the event batch was 
+    
+    private Map<String, List<Long>> timestampsMS = new HashMap<>();
+    private long acknowledgedLatency;
+    private long postResponseLatency;
+    private long timeInLoadBalancer;
+    
+    
+    private EventBatch eb;
+            
+    public LifecycleMetrics(EventBatch eb) {
+        this.eb = eb;
+    }
+    
+    public List<Long> getCreationTimestamp() {
+        return timestampsMS.get(CREATION_TIMESTAMP);
+    }
+
+    public void setCreationTimestamp(Long timestamp) {
+        if (timestampsMS.containsKey(CREATION_TIMESTAMP)) {
+            throw new RuntimeException("Illegal attempt to set creation timestamp twice.");
+        }
+        setTimestamp(CREATION_TIMESTAMP, timestamp);
+    }
+
+    public List<Long> getStartLBSpinTimestamp() {
+        return timestampsMS.get(START_LB_SPIN_TIMESTAMP);
+    }
+
+    public void setStartLBSpinTimestamp(Long timestamp) {
+        setTimestamp(START_LB_SPIN_TIMESTAMP, timestamp);
+    }
+
+    public List<Long> getPostSentTimestamp() {
+        return timestampsMS.get(POST_SENT_TIMESTAMP);
+    }
+
+    public void setPostSentTimestamp(Long timestamp) {
+        List<Long> lbStartTimes = timestampsMS.get(START_LB_SPIN_TIMESTAMP);
+        timeInLoadBalancer = timestamp - lbStartTimes.get(lbStartTimes.size() - 1);
+        setTimestamp(POST_SENT_TIMESTAMP, timestamp);
+    }
+
+    public List<Long> getPostResponseTimeStamp() {
+        return timestampsMS.get(POST_RESPONSE_TIMESTAMP);
+    }
+
+    public void setPostResponseTimeStamp(Long timestamp) {
+        List<Long> sentTimes = timestampsMS.get(POST_SENT_TIMESTAMP);
+        postResponseLatency = timestamp - sentTimes.get(sentTimes.size() - 1);
+        setTimestamp(POST_RESPONSE_TIMESTAMP, timestamp);
+    }
+
+    public List<Long> getAckedTimestamp() {
+        return timestampsMS.get(ACKED_TIMESTAMP);
+    }
+
+    public void setAckedTimestamp(Long timestamp) {
+        List<Long> sentTimes = timestampsMS.get(POST_SENT_TIMESTAMP);
+        acknowledgedLatency = timestamp - sentTimes.get(sentTimes.size() - 1);
+        setTimestamp(ACKED_TIMESTAMP, timestamp);
+    }
+
+    public List<Long> getFailedTimestamp() {
+        return timestampsMS.get(FAILED_TIMESTAMP);
+    }
+
+    public void setFailedTimestamp(Long timestamp) {
+        setTimestamp(FAILED_TIMESTAMP, timestamp);
+    }
+
+    public Long getAcknowledgedLatency() {
+        return acknowledgedLatency;
+    }
+
+    public Long getPostResponseLatency() {
+        return postResponseLatency;
+    }
+    
+    public Long getTimeInLoadBalancer() {
+        return timeInLoadBalancer;
+    }
+
+    private void setTimestamp(String key, Long timestamp) {
+        timestampsMS.putIfAbsent(key, new ArrayList<>());
+        timestampsMS.get(key).add(timestamp);
+    }
+}

--- a/src/main/java/com/splunk/cloudfwd/impl/EventBatchImpl.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/EventBatchImpl.java
@@ -16,6 +16,7 @@
 package com.splunk.cloudfwd.impl;
 
 import com.splunk.cloudfwd.Event;
+import com.splunk.cloudfwd.LifecycleMetrics;
 import com.splunk.cloudfwd.impl.http.HecIOManager;
 import com.splunk.cloudfwd.LifecycleEvent;
 import static com.splunk.cloudfwd.LifecycleEvent.Type.EVENT_BATCH_BORN;
@@ -73,6 +74,11 @@ public class EventBatchImpl implements EventBatch {
   private HecChannel hecChannel;
   private LifecycleEvent.Type state = EVENT_BATCH_BORN; //initial lifecyle state
   private List<Exception> sendExceptions = new ArrayList<>();
+  final private LifecycleMetrics lifecycleMetrics = new LifecycleMetrics(this);
+  
+  public EventBatchImpl() {
+    lifecycleMetrics.setCreationTimestamp(System.currentTimeMillis());
+  }
 
   @Override
   public synchronized void prepareToResend() {
@@ -360,6 +366,11 @@ public class EventBatchImpl implements EventBatch {
     public void setFailed(boolean failed) {
         this.failed = failed;
     }
+
+  @Override
+  public LifecycleMetrics getLifecycleMetrics() {
+    return this.lifecycleMetrics;
+  }
 
   private class HttpEventBatchEntity extends AbstractHttpEntity {
 

--- a/src/main/java/com/splunk/cloudfwd/impl/http/HttpSender.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/HttpSender.java
@@ -311,7 +311,7 @@ public final class HttpSender implements Endpoints, CookieClient {
     if (!started()) {
       start();
     }
-    
+    ((EventBatch)events).getLifecycleMetrics().setPostSentTimestamp(System.currentTimeMillis());
     if (isSimulated()) {
       this.simulatedEndpoints.postEvents(events, httpCallback);
       return;
@@ -331,7 +331,6 @@ public final class HttpSender implements Endpoints, CookieClient {
     HttpEntity e= events.getEntity();
     LOG.debug("executing event batch post on channel={}, eventBatch={}", getChannel(), e.toString());
     httpPost.setEntity(e);
-    ((EventBatch)events).getLifecycleMetrics().setPostSentTimestamp(System.currentTimeMillis());
     httpClient.execute(httpPost, httpCallback);
   }
 

--- a/src/main/java/com/splunk/cloudfwd/impl/http/HttpSender.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/HttpSender.java
@@ -331,6 +331,7 @@ public final class HttpSender implements Endpoints, CookieClient {
     HttpEntity e= events.getEntity();
     LOG.debug("executing event batch post on channel={}, eventBatch={}", getChannel(), e.toString());
     httpPost.setEntity(e);
+    ((EventBatch)events).getLifecycleMetrics().setPostSentTimestamp(System.currentTimeMillis());
     httpClient.execute(httpPost, httpCallback);
   }
 

--- a/src/main/java/com/splunk/cloudfwd/impl/http/httpascync/HttpCallbacksEventPost.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/httpascync/HttpCallbacksEventPost.java
@@ -64,6 +64,7 @@ public class HttpCallbacksEventPost extends HttpCallbacksAbstract {
 
     @Override
     public void completed(String reply, int code) {
+        events.getLifecycleMetrics().setPostResponseTimeStamp(System.currentTimeMillis());
         try {
             switch (code) {
                 case 200:

--- a/src/main/java/com/splunk/cloudfwd/impl/util/CallbackInterceptor.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/CallbackInterceptor.java
@@ -45,6 +45,7 @@ public class CallbackInterceptor implements ConnectionCallbacks {
     public void acknowledged(EventBatch events) {
         try {
             ((EventBatchImpl) events).cancelEventTrackers(); //remove the EventBatchImpl from the places in the system it should be removed
+            events.getLifecycleMetrics().setAckedTimestamp(System.currentTimeMillis());
             callbacks.acknowledged(events);
         } catch (Exception e) {
             LOG.error("Caught exception from ConnectionCallbacks.acknowledged: " + e.getMessage());
@@ -61,6 +62,7 @@ public class CallbackInterceptor implements ConnectionCallbacks {
                     return;
                 }
                 ((EventBatchImpl)events).setFailed(true);
+                events.getLifecycleMetrics().setFailedTimestamp(System.currentTimeMillis());
                 ((EventBatchImpl)events).cancelEventTrackers();//remove the EventBatchImpl from the places in the system it should be removed
             }
             this.callbacks.failed(events, ex);

--- a/src/main/java/com/splunk/cloudfwd/impl/util/LoadBalancer.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/LoadBalancer.java
@@ -317,6 +317,7 @@ public class LoadBalancer implements Closeable {
 
     private boolean spinSend(boolean resend, EventBatchImpl events) throws HecNoValidChannelsException {
         long startTime = System.currentTimeMillis();
+        events.getLifecycleMetrics().setStartLBSpinTimestamp(startTime);
         int spinCount = 0;
         while (true) {
             if (interrupted || (closed && !resend)) {

--- a/src/test/java/com/splunk/cloudfwd/test/mock/LifecycleMetricsTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/LifecycleMetricsTest.java
@@ -1,0 +1,70 @@
+package com.splunk.cloudfwd.test.mock;
+
+import com.splunk.cloudfwd.EventBatch;
+import com.splunk.cloudfwd.Events;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Created by eprokop on 12/21/17.
+ */
+public class LifecycleMetricsTest {
+    EventBatch eb;
+    
+    @Before
+    public void createBatch() {
+       this.eb = Events.createBatch();
+    }
+    
+    @Test
+    public void testCreationTimestamp() {
+        Exception e = null;
+        try {
+            eb.getLifecycleMetrics().setCreationTimestamp(System.currentTimeMillis());
+        } catch (RuntimeException ex) {
+            e = ex;
+        }
+        Assert.assertNotNull("Expected exception from illegally setting timestamp", e);
+        Assert.assertNotNull("creation timestamp shouldn't be null", eb.getLifecycleMetrics().getCreationTimestamp());
+    }
+    
+    @Test
+    public void testAckedTimestamp() {
+        long time = System.currentTimeMillis();
+        eb.getLifecycleMetrics().setStartLBSpinTimestamp(time - 1);
+        eb.getLifecycleMetrics().setPostSentTimestamp(time);
+        eb.getLifecycleMetrics().setAckedTimestamp(time + 1);
+        Assert.assertEquals("acked latency should be 1", 1, (long)eb.getLifecycleMetrics().getAcknowledgedLatency());
+        Assert.assertEquals("timestamps should match", time + 1, (long)eb.getLifecycleMetrics().getAckedTimestamp().get(0));
+    }
+
+    @Test
+    public void testFailedTimestamp() {
+        long time = System.currentTimeMillis();
+        eb.getLifecycleMetrics().setFailedTimestamp(time);
+        Assert.assertEquals("timestamps should match", time, (long)eb.getLifecycleMetrics().getFailedTimestamp().get(0));
+    }
+    
+    @Test
+    public void testEnteredLoadBalancerTimestamp() {
+        long time = System.currentTimeMillis();
+        eb.getLifecycleMetrics().setStartLBSpinTimestamp(time);
+        eb.getLifecycleMetrics().setStartLBSpinTimestamp(time + 1);
+        eb.getLifecycleMetrics().setPostSentTimestamp(time + 2);
+        Assert.assertEquals("timestamps should match", time, (long)eb.getLifecycleMetrics().getStartLBSpinTimestamp().get(0));
+        Assert.assertEquals("timestamps should match", time + 1, (long)eb.getLifecycleMetrics().getStartLBSpinTimestamp().get(1));
+        Assert.assertEquals("time in load balancer is incorrect", 1, (long)eb.getLifecycleMetrics().getTimeInLoadBalancer());
+    }
+    
+    @Test
+    public void testPostResponseTimestamp() {
+        long time = System.currentTimeMillis();
+        eb.getLifecycleMetrics().setStartLBSpinTimestamp(time - 1);
+        eb.getLifecycleMetrics().setPostSentTimestamp(time);
+        eb.getLifecycleMetrics().setPostResponseTimeStamp(time + 1);
+        Assert.assertEquals("timestamps should match", time, (long)eb.getLifecycleMetrics().getPostSentTimestamp().get(0));
+        Assert.assertEquals("timestamps should match", time + 1, (long)eb.getLifecycleMetrics().getPostResponseTimeStamp().get(0));
+        Assert.assertEquals("latency should be 1", 1, (long)eb.getLifecycleMetrics().getPostResponseLatency());
+    }
+}


### PR DESCRIPTION
Add LifecycleMetrics class (eventBatch.getLifecycleMetrics()) that provides access to the following data for each event batch:

- batch creation timestamp
- start spinning in load balancer timestamp
- event batch post request sent timestamp
- time in load balancer (MS)
- event batch post response received timestamp
- event batch post response latency (MS)
- event batch ack received timestamp
- event batch ack latency (MS)
- event batch failed timestamp

The timestamp getters return a list, as some of the data may have multiple values in the case of resends. Many are expected to only have one value.