### PR TITLE
Resend on blocking timeout during resend

### DIFF
--- a/src/main/java/com/splunk/cloudfwd/impl/http/httpascync/HttpCallbacksEventPost.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/httpascync/HttpCallbacksEventPost.java
@@ -68,7 +68,6 @@ public class HttpCallbacksEventPost extends HttpCallbacksAbstract {
     @Override
     public void completed(String reply, int code) {
         events.getLifecycleMetrics().setPostResponseTimeStamp(System.currentTimeMillis());
-        LOG.info("Event with id = {}  on channel = {} received a response of {}",events.getId(),  getChannel(),code);
         try {
             switch (code) {
                 case 200:
@@ -119,7 +118,7 @@ public class HttpCallbacksEventPost extends HttpCallbacksAbstract {
             Exception exc = ex;
             while(!events.isFailed()) {
                 try {
-                    LOG.info("Entered into resend for id = {}. The number of times its in resend is = {}",events.getId(),events.getNumTries());
+                    LOG.info("Entered into resend for id = {}. The number of times its in resend is {}",events.getId(),events.getNumTries());
                     if(trackSendExceptionAndResend(exc)){
                         break;
                     }

--- a/src/main/java/com/splunk/cloudfwd/impl/util/LoadBalancer.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/LoadBalancer.java
@@ -375,7 +375,7 @@ public class LoadBalancer implements Closeable {
                 if (tryChannelSend(channelsSnapshot, events, resend)) {//attempt to send through a channel (ret's false if channel not available)
                     //the following wait must be done *after* success sending else multithreads can fill the connection and nothing sends
                     //because everyone stuck in perpetual wait
-                    //waitWhileFull(startTime, events, closed); //apply backpressure if connection is globally full 
+                    //waitWhileFull(startTime, events, closed); //apply backpressure if connection is globally full
                     break;
                 }
             }
@@ -615,7 +615,7 @@ public class LoadBalancer implements Closeable {
         }
         if (events.isAcknowledged() || events.isTimedOut(connection.
                 getSettings().getAckTimeoutMS())) {
-            return false; //do not resend messages that are in a final state 
+            return false; //do not resend messages that are in a final state
         }
         events.prepareToResend(); //we are going to resend it,so mark it not yet flushed, cancel its acknowledgement tracker, etc
         return true;

--- a/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/perf/MultiThreadedVolumeTest.java
@@ -39,7 +39,7 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
         cliProperties.put(MAX_THREADS_KEY, "300");
         cliProperties.put(DURATION_MINUTES_KEY, "15");
         cliProperties.put(MAX_MEMORY_MB_KEY, "1024"); //500MB
-        cliProperties.put(NUM_SENDERS_KEY, "384"); 
+        cliProperties.put(NUM_SENDERS_KEY, "384");
         cliProperties.put(PropertyKeys.TOKEN, null); // will use token in cloudfwd.properties by default
         cliProperties.put(PropertyKeys.COLLECTOR_URI, null); // will use token in cloudfwd.properties by default
         cliProperties.put(ENABLE_LIFECYCLE_METRICS_LOGGING_KEY, "false");
@@ -172,7 +172,7 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
         Integer numSent = batchCounter.get();
         float percentFailed = ( (float) numFailed / (float) numSent ) * 100F;
         LOG.info("Failed count: " + numFailed + " / " + numSent + " failed callbacks. (" + percentFailed + "%)");
-        
+
         // acknowledged throughput
         int numAckedBatches = callbacks.getAcknowledgedBatches().size();
         long elapsedSeconds = (System.currentTimeMillis() - testStartTimeMillis) / 1000;
@@ -238,7 +238,7 @@ public class MultiThreadedVolumeTest extends AbstractPerformanceTest {
 //                            }
 //                        }
                         if(!failed){
-                            LOG.info("sender {} ackd {} in {} ms", this.workerNumber, eb.getLength(), System.currentTimeMillis()- ((EventBatchImpl)eb).getSendTimestamp());                        
+                            LOG.info("sender {} ackd {} in {} ms", this.workerNumber, eb.getLength(), System.currentTimeMillis()- ((EventBatchImpl)eb).getSendTimestamp());
                         }else{
                             LOG.info("sender {} failed in {} ms", this.workerNumber, System.currentTimeMillis()- ((EventBatchImpl)eb).getSendTimestamp());
                         }


### PR DESCRIPTION
The event gets retired until the max retries(10 times) is reached rather than failing immediately on blocking timeout (5 Seconds) after a single try