### PR TITLE
Faster tests

### DIFF
--- a/src/main/java/com/splunk/cloudfwd/impl/sim/CannedOKHttpResponse.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/CannedOKHttpResponse.java
@@ -23,6 +23,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.message.BasicHeader;
+import org.apache.http.message.HeaderGroup;
 import org.apache.http.params.HttpParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
 public class CannedOKHttpResponse implements HttpResponse{
   protected static final Logger LOG = LoggerFactory.getLogger(CannedOKHttpResponse.class.getName());
   HttpEntity entity;
+  HeaderGroup headers = new HeaderGroup();
 
   public CannedOKHttpResponse(HttpEntity entity) {
     this.entity = entity;
@@ -105,10 +107,14 @@ public class CannedOKHttpResponse implements HttpResponse{
         return new Header[]{};
       //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
-
+  
+  
     @Override
     public Header getFirstHeader(String string) {
-      throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+      for (Header h: headers.getAllHeaders()) {
+        if(h.getName().equals(string)) { return h; }
+      }
+      return null;
     }
 
     @Override
@@ -118,7 +124,7 @@ public class CannedOKHttpResponse implements HttpResponse{
 
     @Override
     public Header[] getAllHeaders() {
-      throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+      return headers.getAllHeaders();
     }
 
     @Override

--- a/src/main/java/com/splunk/cloudfwd/impl/sim/CookiedOKHttpResponse.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/CookiedOKHttpResponse.java
@@ -31,7 +31,6 @@ public class CookiedOKHttpResponse extends CannedOKHttpResponse {
     protected static final Logger LOG = LoggerFactory.getLogger(CookiedOKHttpResponse.class.getName());
     String cookie;
     String syncAck = null;
-    HeaderGroup headers = new HeaderGroup();
     
     public CookiedOKHttpResponse(HttpEntity entity, String cookie) {
         super(entity);
@@ -42,14 +41,6 @@ public class CookiedOKHttpResponse extends CannedOKHttpResponse {
         this(entity, cookie);
         this.syncAck = syncAck;
         this.cookie = cookie;
-    }
-    
-    @Override
-    public Header getFirstHeader(String string) {
-        for (Header h: headers.getAllHeaders()) {
-            if(h.getName().equals(string)) { return h; } 
-        }
-        return null;
     }
 
     @Override

--- a/src/main/java/com/splunk/cloudfwd/impl/sim/errorgen/slow/SlowEndpoints.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/errorgen/slow/SlowEndpoints.java
@@ -28,8 +28,8 @@ import org.apache.http.concurrent.FutureCallback;
  * @author ghendrey
  */
 public class SlowEndpoints extends SimulatedHECEndpoints {
-  public static long sleep = 10000; //10 second
-
+  public static long sleep = 1000; //1 second
+  
   @Override
   public void pollAcks(HecIOManager ackMgr,
           FutureCallback<HttpResponse> httpCallback) {

--- a/src/test/java/com/splunk/cloudfwd/test/mock/BatchedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/BatchedVolumeTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeoutException;
  */
 public class BatchedVolumeTest extends AbstractConnectionTest {
 
-  protected int numToSend = 1000000;
+  protected int numToSend = 100000;
 
   public BatchedVolumeTest() {
   }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/CloseNowTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/CloseNowTest.java
@@ -22,7 +22,7 @@ public class CloseNowTest extends AbstractConnectionTest {
 
     @Override
     protected int getNumEventsToSend() {
-        return 500000;
+        return 5000;
     }
     
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ConnectionTimeoutTest.java
@@ -43,7 +43,9 @@ public class ConnectionTimeoutTest extends AbstractConnectionTest {
     settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.slow.SlowEndpoints");
     settings.setMaxUnackedEventBatchPerChannel(1);
     settings.setMaxTotalChannels(1);
+    settings.setMaxTotalChannels(1);
     settings.setAckTimeoutMS(60000);
+    settings.setBlockingTimeoutMS(750);
     settings.setAckPollMS(250);
     settings.setUnresponsiveMS(-1);
   }

--- a/src/test/java/com/splunk/cloudfwd/test/mock/GatewayTimeoutTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/GatewayTimeoutTest.java
@@ -21,13 +21,13 @@ public class GatewayTimeoutTest extends AbstractConnectionTest {
     @Override
     protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostGatewayTimeoutEndpoints");
-        settings.setBlockingTimeoutMS(5000);
+        settings.setBlockingTimeoutMS(1000);
         settings.setAckTimeoutMS(500000);
     }
 
     @Override
     protected int getNumEventsToSend() {
-        return 3;
+        return 2;
     }
 
     @Override

--- a/src/test/java/com/splunk/cloudfwd/test/mock/NonBatchedVolumeTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/NonBatchedVolumeTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
  */
 public class NonBatchedVolumeTest extends AbstractConnectionTest {
 
-  protected int numToSend = 1000000;
+  protected int numToSend = 100000;
 
   @Test
   public void sendWithoutBatching() throws InterruptedException, TimeoutException, HecConnectionTimeoutException {

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdWithFailTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderAckIdWithFailTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  */
 public class OutOfOrderAckIdWithFailTest extends AbstractConnectionTest {
 
-    final int n = 100;
+    final int n = 10;
     boolean fail = true;
 
     
@@ -71,7 +71,7 @@ public class OutOfOrderAckIdWithFailTest extends AbstractConnectionTest {
                 "SENDING EVENTS WITH CLASS GUID: " + TEST_CLASS_INSTANCE_GUID
                         + "And test method GUID " + testMethodGUID);
           for (int i = 0; i < expected; i++) {
-              if (i % 25 == 0) {
+              if (i % (n/4) == 0) {
                 fail = !fail; //0-25:ok, 26-50: fail, 51-75:fail, 76-100:ok
                 OutOfOrderAckIDFailEndpoints.toggleFail(fail);
               }            
@@ -94,7 +94,7 @@ public class OutOfOrderAckIdWithFailTest extends AbstractConnectionTest {
     @Override
     protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.acks.OutOfOrderAckIDFailEndpoints");
-        settings.setBlockingTimeoutMS(30000);
+        settings.setBlockingTimeoutMS(3000);
         settings.setUnresponsiveMS(-1); //no dead channel detection
         settings.setMaxTotalChannels(4);
         settings.setAckTimeoutMS(60000); //we don't want the ack timout kicking in

--- a/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderIdTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/OutOfOrderIdTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
  */
 public class OutOfOrderIdTest extends AbstractConnectionTest {
 
-    final int n = 100000;
+    final int n = 10000;
     
     @Test
     public void testOutofOrderIDsWithCheckpointDisabled() throws InterruptedException{

--- a/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/hec_server_error_response_tests/HecServerErrorResponseIndexerBusyButHealthCheckOKTest.java
@@ -54,7 +54,7 @@ public class HecServerErrorResponseIndexerBusyButHealthCheckOKTest extends Abstr
     protected void configureProps(ConnectionSettings settings) {
         settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.unhealthy.EventPostIndexerBusyEndpoints");
         settings.setAckTimeoutMS(500000); //in this case we excpect to see HecConnectionTimeoutException
-        settings.setBlockingTimeoutMS(5000);
+        settings.setBlockingTimeoutMS(1000);
     }
 
     @Override


### PR DESCRIPTION
Decrease mocked tests run from 8 to 3 minutes by optimizing test and connection settings. Add methods to return headers to mocked responses. 