### PR TITLE
Add new test SessionCookiesRandomTest to Randomize Session Cookie for…

### DIFF
--- a/src/main/java/com/splunk/cloudfwd/impl/http/AcknowledgementTracker.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/AcknowledgementTracker.java
@@ -15,6 +15,7 @@
  */
 package com.splunk.cloudfwd.impl.http;
 
+import com.splunk.cloudfwd.error.HecNonStickySessionException;
 import com.splunk.cloudfwd.impl.EventBatchImpl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -94,6 +95,9 @@ public class AcknowledgementTracker implements EventTracker {
           return;
       }
     Long ackId = epr.getAckId();
+    if (polledAcksByAckId.get(ackId) != null) {
+      throw new HecNonStickySessionException("Got duplucated ackId=" + ackId);
+    }
     polledAcksByAckId.put(ackId, events);
   }
 

--- a/src/main/java/com/splunk/cloudfwd/impl/http/ChannelCookies.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/ChannelCookies.java
@@ -1,0 +1,86 @@
+package com.splunk.cloudfwd.impl.http;
+
+import com.splunk.cloudfwd.impl.util.HecChannel;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.slf4j.Logger;
+
+import java.net.HttpCookie;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Stores Session Cookie 
+ */
+public class ChannelCookies implements Cloneable {
+  
+  private final Logger LOG; 
+  private List<HttpCookie> cookies = new ArrayList<>();
+  private HecChannel channel;
+  
+  private static final String PATH_NAME = "PATH"; 
+  private static final String MAX_AGE_NAME = "MAX-AGE";
+  
+  /**
+   * Session Cookie object. 
+   * 
+   * Example ELB Set-Cookie header
+   * Set-Cookie: AWSELB=633765DB082FD002198A92E31DFFD5BDEA5A74557F84FE2BE8A8B6F6EEFD920BEF75DDED44CED67DBEBCCEB6B8164F3FE2216A8454BB86B94FD977DDF4E76E95766567589D;PATH=/;MAX-AGE=1
+   */
+  public ChannelCookies(HecChannel channel, HttpResponse response) {
+    this.LOG = channel.getConnection().getLogger(ChannelCookies.class.getName());
+    Header[] headers = response.getHeaders("Set-Cookie");
+    try {
+      for (Header header: headers) {
+        cookies.addAll(HttpCookie.parse(header.toString()));
+      }
+    } catch (Exception e) {
+      LOG.error("channel={} headers={} cookies={}", channel, headers, cookies);
+      throw e;
+    }
+    LOG.debug("channel={} headers={} cookies={}", channel, headers, cookies);
+  }
+  
+  public boolean isEmpty(){ 
+    return this.cookies == null || this.cookies.isEmpty();
+  }
+  
+  public boolean equals(ChannelCookies cookies1) {
+    return this.toString().equalsIgnoreCase(cookies1.toString());
+  }
+  
+  public String toString() {
+    return getCookieHeader();
+  }
+  
+  /**
+   * Checks if Expiration or MAX-AGE is set
+   */
+  public boolean isExpirationSet() {
+      for (HttpCookie cookie: cookies) {
+        LOG.debug("ChannelCookies: isExpirationSet: cookie_max_age={}", cookie.getMaxAge());
+        if (cookie.getMaxAge() >= 0 ) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public String getCookieHeader() {
+    if (cookies == null) {
+      return null;
+    }
+    List<String> cookie_headers = new ArrayList<>(); 
+    StringBuffer sb = new StringBuffer();
+    for (HttpCookie cookie: cookies) {
+      String cookie_header = cookie.getName() + "=" + cookie.getValue() +
+              ";" + PATH_NAME + "=" + cookie.getPath();
+      if(cookie.getMaxAge() != 0) {
+        cookie_header = cookie_header + ";" + MAX_AGE_NAME + "=" + cookie.getMaxAge();
+      }
+      cookie_headers.add(cookie_header);
+    }
+    return String.join(",", cookie_headers);
+  }
+}

--- a/src/main/java/com/splunk/cloudfwd/impl/http/HecIOManager.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/HecIOManager.java
@@ -18,6 +18,7 @@ package com.splunk.cloudfwd.impl.http;
 import com.splunk.cloudfwd.LifecycleEvent;
 import com.splunk.cloudfwd.impl.ConnectionImpl;
 import com.splunk.cloudfwd.impl.EventBatchImpl;
+import com.splunk.cloudfwd.impl.http.httpascync.CoordinatedFirstResponseHandler;
 import com.splunk.cloudfwd.impl.http.httpascync.GenericCoordinatedResponseHandler;
 import com.splunk.cloudfwd.impl.http.httpascync.HttpCallbacksAckPoll;
 import com.splunk.cloudfwd.impl.http.httpascync.HttpCallbacksEventPost;
@@ -173,7 +174,7 @@ public class HecIOManager implements Closeable {
                 ()->{      
                     try {
                           LOG.info("preflight checks on {}", sender.getChannel());
-                          GenericCoordinatedResponseHandler cb1 = new GenericCoordinatedResponseHandler(
+                          GenericCoordinatedResponseHandler cb1 = new CoordinatedFirstResponseHandler(
                                   this,
                                   LifecycleEvent.Type.PREFLIGHT_OK,
                                   LifecycleEvent.Type.PREFLIGHT_FAILED,

--- a/src/main/java/com/splunk/cloudfwd/impl/http/HttpSender.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/HttpSender.java
@@ -19,6 +19,7 @@ package com.splunk.cloudfwd.impl.http;
  */
 import com.splunk.cloudfwd.error.HecConnectionStateException;
 import com.splunk.cloudfwd.error.HecIllegalStateException;
+import com.splunk.cloudfwd.error.HecNonStickySessionException;
 import com.splunk.cloudfwd.impl.ConnectionImpl;
 import com.splunk.cloudfwd.*;
 import com.splunk.cloudfwd.impl.CookieClient;
@@ -39,6 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.splunk.cloudfwd.impl.util.ThreadScheduler;
 import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.client.utils.URIBuilder;
 
@@ -46,7 +49,7 @@ import org.apache.http.client.utils.URIBuilder;
  * This class performs the actually HTTP send to HEC
  * event collector.
  */
-public final class HttpSender implements Endpoints, CookieClient {
+public final class HttpSender implements Endpoints{
 
   // Default to SLF4J Logger, and set custom LoggerFactory when channel (and therefore Connection instance) is available
   private Logger LOG = LoggerFactory.getLogger(HttpSender.class.getName());
@@ -78,12 +81,13 @@ public final class HttpSender implements Endpoints, CookieClient {
   private Endpoints simulatedEndpoints;
   private final HecIOManager hecIOManager;
   private final String baseUrl; 
-  private String cookie;
+  private ChannelCookies cookies;
   //the following  posts/gets are used by health checks and preflight checks. We record them so we can cancel them on close. 
   private HttpPost ackCheck;
   private HttpGet healthEndpointCheck;
   private HttpPost dummyEventPost;
   private final ConnectionSettings connectionSettings;
+  private boolean stickySessionViolation = false;
 
   /**
    * Initialize HttpEventCollectorSender
@@ -290,9 +294,29 @@ public final class HttpSender implements Endpoints, CookieClient {
       setCookieHeader(r);
   }
   
+  public void checkStickySesssionViolation(HttpResponse response) {
+    ChannelCookies cookies = new ChannelCookies(getChannel(), response);
+    LOG.debug("checkStickySesssionViolation: response={} cookies={}", response, cookies);
+    if(cookies.isEmpty()) return;
+    if(this.cookies.equals(cookies)){
+      LOG.warn("Received a HTTP Response with unexpected cookie. Cookie should " +
+              "be set only once in the first pre-flight response "+
+              "channel=" + getChannel() +
+              "cookies=" + cookies.toString());
+    } else {
+      HecNonStickySessionException ex = new HecNonStickySessionException(
+              "Received a HTTP Response with a cookie set which does " +
+              "not match this channel cookie " +
+              "channel=" + getChannel() +
+              " cookies=" + cookies.toString());
+      handleStickySessionViolation(ex);
+      throw ex;
+    }
+  } 
+  
   private void setCookieHeader(HttpRequestBase r){
-      if(null != this.cookie && !this.cookie.isEmpty()){
-          r.setHeader("Cookie", this.cookie);
+      if(null != this.cookies && !this.cookies.isEmpty()){
+          r.setHeader("Cookie", this.cookies.getCookieHeader());
       }
   }
   
@@ -505,30 +529,62 @@ public final class HttpSender implements Endpoints, CookieClient {
   public String getBaseUrl() {
     return baseUrl;
   }
-
-    @Override
-    public void setSessionCookies(String cookie) {
-        if (null == cookie || cookie.isEmpty()) {
-            return;
-        }
-        if (null != this.cookie && !this.cookie.equals(cookie)) {
-            synchronized (this) { //we don't want to make multiple attempts to handle the same detected change
-                if (null != this.cookie && !this.cookie.equals(cookie) &&
-                        !getChannel().isQuiesced()) { //must double-check the condition once inside sync'd block
-                    LOG.warn(
-                            "An attempt was made to change the Session-Cookie from {} to {} on {}",
-                            this.cookie, cookie, getChannel());
-                    this.cookie = cookie; //record the new cookie so that subsequent same cookies don't try to resend again                    
-                    LOG.warn("replacing channel, resending events, and killing {}",
-                            getChannel());
-                    getChannel().killAckTracker(); //we want to immediately ignore any in-flight acks that could arrive from the channel
-                    getChannel().close(); //close the channel as quickly as possible to prevent more event piling into it
-                    dispatchChannelCloseAndReplace(); //will ultimately result in this channel getting killed
-                }
-            }//end sync
-        } else {
-            this.cookie = cookie;
-        }
+  
+  /**
+   * 
+   * @param cause
+   */
+  public synchronized void handleStickySessionViolation(Exception cause) {
+    if(stickySessionViolation) {
+      LOG.warn("handleStickySessionViolation: attempt to handle already handled channel={}", getChannel());
+      return;
+    }
+    stickySessionViolation = true;
+    try {
+      //FIXME: move hardcoded value to parameters
+      LOG.debug("handleStickySessionViolation backing off for 10 seconds");
+      Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+    } catch (InterruptedException e) {
+      LOG.warn("handleStickySessionViolation was interrupted, e_message={}", e.getMessage());
+      return; 
+    }
+    LOG.warn("handleStickySessionViolation: casuse={} cause_message={}", cause, cause.getMessage());
+    getChannel().killAckTracker(); //we want to immediately ignore any in-flight acks that could arrive from the channel
+    getChannel().close(); //close the channel as quickly as possible to prevent more event piling into it
+    dispatchChannelCloseAndReplace(); //will ultimately result in this channel getting killed
+  }
+    
+  public void setCookies(ChannelCookies cookies) {
+    if (this.cookies != null) {
+      LOG.error("setCookies: unexpected setCookie." + 
+              "Attempt to set cookies on a channel with cookies already set." +
+              " channel=" + getChannel() +
+                      " channel.cookies=" + this.cookies +
+                      " cookies=" + cookies.toString());
+      handleStickySessionViolation(new RuntimeException(
+              "Attempt to set cookies on a channel with cookies already set." +
+              " channel=" + getChannel() +
+              " channel.cookies=" + this.cookies + 
+              " cookies=" + cookies.toString())); 
+    }
+    if(cookies.isExpirationSet()){
+      LOG.debug("Received a HTTP Response with a cookie with an expiration time" +
+              "configured " +
+              "channel=" + getChannel() +
+              " cookies=" + cookies.toString());
+      HecNonStickySessionException ex = new HecNonStickySessionException(
+              "Received a HTTP Response with a cookie with an expiration time" +
+                      "configured " +
+                      "channel=" + getChannel() +
+                      " cookies=" + cookies.toString());
+      handleStickySessionViolation(ex);
+      throw ex;
+    }
+    this.cookies = cookies;
+  }
+    
+    public String getCookies() {
+      return this.cookies.getCookieHeader();
     }
     
     private void dispatchChannelCloseAndReplace(){
@@ -538,7 +594,7 @@ public final class HttpSender implements Endpoints, CookieClient {
                 getChannel().closeAndReplaceAndFail();
             } catch (Exception ex) {
                 ex.printStackTrace();
-                LOG.error("Exception '{}' trying to handle sticky session-cookie violation on channel={}", ex.getMessage(), getChannel(), ex);
+                LOG.error("Exception '{}' trying to handle sticky session-cookies violation on channel={}", ex.getMessage(), getChannel(), ex);
             }
         };//end runnable
         ThreadScheduler.getSharedExecutorInstance("event_resender").execute(r);

--- a/src/main/java/com/splunk/cloudfwd/impl/http/httpascync/CoordinatedFirstResponseHandler.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/http/httpascync/CoordinatedFirstResponseHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Splunk, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splunk.cloudfwd.impl.http.httpascync;
+
+import com.splunk.cloudfwd.LifecycleEvent;
+import com.splunk.cloudfwd.impl.http.HecIOManager;
+import com.splunk.cloudfwd.impl.http.ChannelCookies;
+import com.splunk.cloudfwd.impl.util.HecChannel;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+
+/**
+ *
+ * @author cloudbuilder
+ */
+public class CoordinatedFirstResponseHandler extends GenericCoordinatedResponseHandler implements CoordinatedResponseHandler{
+
+    private Logger LOG;
+    private ResponseCoordinator coordinator;
+    
+
+    public CoordinatedFirstResponseHandler(HecIOManager m, LifecycleEvent.Type okType,
+                                           LifecycleEvent.Type failType, String name) {
+        super(m, okType, failType, name);  
+        this.LOG = m.getSender().getConnection().getLogger(
+                HttpCallbacksGeneric.class.
+                getName());
+    }
+    
+    public CoordinatedFirstResponseHandler(HecIOManager m, LifecycleEvent.Type okType,
+                                           LifecycleEvent.Type failType, LifecycleEvent.Type gatewayTimeoutType,
+                                           LifecycleEvent.Type indexerBusyType, String name) {
+        super(m, okType, failType, gatewayTimeoutType, indexerBusyType, name);
+        this.LOG = m.getSender().getConnection().getLogger(
+                HttpCallbacksGeneric.class.
+                        getName());
+    }
+    
+    @Override
+    public void completed(HttpResponse response) {
+        try {
+            ChannelCookies cookies = new ChannelCookies((HecChannel)getChannel(), response);
+            getSender().setCookies(cookies);
+            int code = response.getStatusLine().getStatusCode();
+            //handleCookies(response);
+            String reply = EntityUtils.toString(response.getEntity(), "utf-8");
+            if(null == reply || reply.isEmpty()){
+                LOG.warn("reply with code {} was empty for function '{}'",code,  getOperation());
+            }
+            completed(reply, code, response);
+        } catch (IOException e) {
+            LOG.error("Unable to get String from HTTP response entity", e);
+            failed(new RuntimeException("Unable to get String from HTTP response entity, response=" + response));
+        } catch (Exception e) {
+            LOG.error("Unexpected exception handling complete callback for response=" + response +
+                    " exception=" + e + "exception_message=" + e.getMessage());
+            failed(new RuntimeException("Unexpected exception handling complete callback for response=" + response + 
+                    " exception=" + e + "exception_message=" + e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/splunk/cloudfwd/impl/sim/CannedOKHttpResponse.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/CannedOKHttpResponse.java
@@ -35,10 +35,12 @@ import org.slf4j.LoggerFactory;
 public class CannedOKHttpResponse implements HttpResponse{
   protected static final Logger LOG = LoggerFactory.getLogger(CannedOKHttpResponse.class.getName());
   HttpEntity entity;
-  HeaderGroup headers = new HeaderGroup();
+  HeaderGroup headers;
 
   public CannedOKHttpResponse(HttpEntity entity) {
-    this.entity = entity;
+    headers = new HeaderGroup();
+    this.entity = entity
+    ;
   }
   
    @Override
@@ -112,7 +114,7 @@ public class CannedOKHttpResponse implements HttpResponse{
     @Override
     public Header getFirstHeader(String string) {
       for (Header h: headers.getAllHeaders()) {
-        if(h.getName().equals(string)) { return h; }
+        if(h.getName().equalsIgnoreCase(string)) { return h; }
       }
       return null;
     }

--- a/src/main/java/com/splunk/cloudfwd/impl/sim/CookiedOKHttpResponse.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/CookiedOKHttpResponse.java
@@ -35,23 +35,26 @@ public class CookiedOKHttpResponse extends CannedOKHttpResponse {
     public CookiedOKHttpResponse(HttpEntity entity, String cookie) {
         super(entity);
         this.cookie = cookie;
+        headers.updateHeader(new BasicHeader("Set-Cookie", this.cookie));
+        LOG.info("getHeaders, headers={}", headers);
     }
     
     public CookiedOKHttpResponse(HttpEntity entity, String cookie, String syncAck) {
         this(entity, cookie);
         this.syncAck = syncAck;
-        this.cookie = cookie;
-    }
-
-    @Override
-    public Header[] getHeaders(String headerName) {
-        if (headerName.equalsIgnoreCase("Set-Cookie")) {
-            headers.updateHeader(new BasicHeader(headerName, this.cookie));
-        }
         if (syncAck != null && syncAck.equals(HttpCallbacksEventPost.ACK_HEADER_SYNC_VALUE)) {
             headers.updateHeader(new BasicHeader(HttpCallbacksEventPost.ACK_HEADER_NAME, this.syncAck));
         }
         LOG.info("getHeaders, headers={}", headers);
+    }
+
+    @Override
+    public Header[] getHeaders(String headerName) {
+        return headers.getHeaders(headerName);
+    }
+    
+    @Override
+    public Header[] getAllHeaders() {
         return headers.getAllHeaders();
     }
 }

--- a/src/main/java/com/splunk/cloudfwd/impl/sim/errorgen/cookies/UpdateableCookieEndpoints.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/errorgen/cookies/UpdateableCookieEndpoints.java
@@ -15,12 +15,9 @@
  */
 package com.splunk.cloudfwd.impl.sim.errorgen.cookies;
 
-import com.splunk.cloudfwd.impl.http.HecIOManager;
 import com.splunk.cloudfwd.impl.http.HttpPostable;
 import com.splunk.cloudfwd.impl.http.httpascync.HttpCallbacksAbstract;
 import com.splunk.cloudfwd.impl.sim.*;
-import com.splunk.cloudfwd.impl.http.HttpPostable;
-import com.splunk.cloudfwd.impl.http.httpascync.HttpCallbacksAbstract;
 
 import com.splunk.cloudfwd.impl.sim.AckEndpoint;
 import com.splunk.cloudfwd.impl.sim.CannedEntity;
@@ -34,14 +31,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.ion.Timestamp;
 
+import java.net.HttpCookie;
+import java.util.Random;
+
 public class UpdateableCookieEndpoints extends SimulatedHECEndpoints {
-    private static final Logger LOG = LoggerFactory.getLogger(UpdateableCookieEndpoints.class.getName());
+    protected static final Logger LOG = LoggerFactory.getLogger(UpdateableCookieEndpoints.class.getName());
 
     private static final String cookie1 = "tasty-cookie=strawberry";
     private static final String cookie2 = "bitter-cookie=crinkles";
 
-    private static String currentCookie = cookie1;
+    protected static String currentCookie = cookie1;
+    private static HttpCookie currentHttpCookie;
     private static String syncAck = null;
+    public static int maxAge;
+    
+    public static final int ELB_COOKIE_LENGTH = 139;
+    public static final String ELB_COOKIE_PATH = "/";
+    public static final String AWSELB_HEADER_TEMPLATE = "AWSELB=%s;PATH=/;MAX-AGE=1";
     
     public static synchronized void toggleCookie() {
         currentCookie = "cookie="+Long.toHexString(Double.doubleToLongBits(Math.random()));
@@ -49,7 +55,7 @@ public class UpdateableCookieEndpoints extends SimulatedHECEndpoints {
     }
     
     public static synchronized void setSyncAck(String syncAckValue) {
-      syncAck = syncAckValue;
+        syncAck = syncAckValue;
     }
     
     @Override

--- a/src/main/java/com/splunk/cloudfwd/impl/sim/errorgen/cookies/UpdateableELBCookieEndpoints.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/sim/errorgen/cookies/UpdateableELBCookieEndpoints.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Splunk, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splunk.cloudfwd.impl.sim.errorgen.cookies;
+
+import com.splunk.cloudfwd.impl.http.HttpPostable;
+import com.splunk.cloudfwd.impl.http.httpascync.HttpCallbacksAbstract;
+import com.splunk.cloudfwd.impl.sim.AckEndpoint;
+import com.splunk.cloudfwd.impl.sim.AcknowledgementEndpoint;
+import com.splunk.cloudfwd.impl.sim.CannedEntity;
+import com.splunk.cloudfwd.impl.sim.CookiedOKHttpResponse;
+import com.splunk.cloudfwd.impl.sim.EventEndpoint;
+import com.splunk.cloudfwd.impl.sim.SimulatedHECEndpoints;
+import com.splunk.cloudfwd.impl.sim.errorgen.PreFlightAckEndpoint;
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.HttpCookie;
+import java.util.Random;
+
+/**
+ * This endpoint emulates an ELB endpoint with stickySession cookie
+ */
+public class UpdateableELBCookieEndpoints extends UpdateableCookieEndpoints {
+    public UpdateableELBCookieEndpoints() {
+        super();
+        toggleELBCookie();
+    }
+    
+    /**
+     * Provides a Generates a new AWSELB cookie. 
+     */
+    public static synchronized void toggleELBCookie() {
+        //FixMe: HttpCookie does not provide methods to print a proper header string, 
+        //so we just construct the header string manually
+        currentCookie = "AWSELB="+ getRandomHexString(ELB_COOKIE_LENGTH) + ";PATH=/";
+        if (maxAge != 0) {
+            currentCookie = currentCookie + ";MAX-AGE=" + String.valueOf(maxAge);
+        }
+        LOG.debug("UpdateableCookieEndpoints.toggleELBCookie currentCookie={}", currentCookie);
+    }
+    
+    /**
+     * Generates a new AWSELB cookie with a MAX-AGE parameter set to maxAge 
+     * @param maxAge
+     */
+    public static synchronized void toggleELBCookie(int maxAge) {
+        UpdateableCookieEndpoints.maxAge = maxAge;
+        toggleELBCookie();
+    }
+    
+    /**
+     * Generates a new random Hex String numchars long 
+     */
+    private static String getRandomHexString(int numchars){
+        Random r = new Random();
+        StringBuffer sb = new StringBuffer();
+        while(sb.length() < numchars){
+            sb.append(Integer.toHexString(r.nextInt()));
+        }
+        return sb.toString().substring(0, numchars);
+    }
+    
+}

--- a/src/main/java/com/splunk/cloudfwd/impl/util/HecChannel.java
+++ b/src/main/java/com/splunk/cloudfwd/impl/util/HecChannel.java
@@ -585,6 +585,7 @@ public class HecChannel implements Closeable, LifecycleEventObserver {
     
     public void closeAndReplaceAndFail() throws InterruptedException {
       closeAndReplace(true);
+      if(!this.preflightCompleted) return;
       for (EventBatchImpl e : getConnection().getUnackedEvents(this)) {
         getConnection().getCallbacks().failed(e, new HecNonStickySessionException("Sticky Session Violation exception"));
       }
@@ -603,7 +604,10 @@ public class HecChannel implements Closeable, LifecycleEventObserver {
       LOG.warn("Force closing dead channel {}", HecChannel.this);
       interalForceClose();
       health.dead();
-      resendInFlightEvents();
+      if(!this.preflightCompleted) {
+        LOG.info("closeAndReplaceAndResend: dispatuching resending of inFlightEvents");
+        resendInFlightEvents();
+      }
     }
 
 

--- a/src/test/java/com/splunk/cloudfwd/test/mock/ELBStickySessionViolationTest.java
+++ b/src/test/java/com/splunk/cloudfwd/test/mock/ELBStickySessionViolationTest.java
@@ -1,0 +1,90 @@
+package com.splunk.cloudfwd.test.mock;
+
+import com.splunk.cloudfwd.Connection;
+import com.splunk.cloudfwd.ConnectionSettings;
+import com.splunk.cloudfwd.Event;
+import com.splunk.cloudfwd.error.HecMaxRetriesException;
+import com.splunk.cloudfwd.error.HecNonStickySessionException;
+import com.splunk.cloudfwd.impl.sim.errorgen.cookies.UpdateableCookieEndpoints;
+import com.splunk.cloudfwd.impl.sim.errorgen.cookies.UpdateableELBCookieEndpoints;
+import com.splunk.cloudfwd.impl.util.HecHealthImpl;
+import com.splunk.cloudfwd.test.util.AbstractConnectionTest;
+import com.splunk.cloudfwd.test.util.BasicCallbacks;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class ELBStickySessionViolationTest extends AbstractConnectionTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ELBStickySessionViolationTest.class.getName());
+
+    @Test
+    public void testWithSessionCookies() throws InterruptedException {
+        List<String> listofChannelIds = getChannelId(this.connection);
+        sendEvents(false, false);
+        
+        List<String> listofChannelsAfterCookieChanges = getChannelId(this.connection);
+        for (String i : listofChannelsAfterCookieChanges) {
+            if (listofChannelIds.contains(i)) {
+                Assert.fail("Channel Id never changed after toggling cookies.");
+            }
+        }
+        connection.close();
+        while(connection.getHealth().size() > 0) {
+            Thread.sleep(5000);
+            LOG.debug("not closed channels in connection, number_of_channels={} healths={}" , connection.getHealth().size(), connection.getHealth());
+        }
+        
+    }
+
+    protected Event nextEvent(int i) {
+        if (i>20 && (i%10) == 0 && i < getNumEventsToSend() / 2) {
+            LOG.trace("Toggling cookies from event 21-100: {}", i);
+            UpdateableELBCookieEndpoints.toggleELBCookie(300);
+        }
+        LOG.debug("number of channels={}", connection.getHealth().size());
+        return super.nextEvent(i);
+    }
+
+
+    @Override
+    protected int getNumEventsToSend() {
+        return 1000;
+    }
+
+    @Override
+    public List<String> getChannelId(Connection connection) {
+        ArrayList channels = new ArrayList();
+        for (Object c : connection.getHealth()) {
+            channels.add(((HecHealthImpl) c).getChannelId());
+        }
+        LOG.info("List of channel ids {}", channels);
+        return channels;
+    }
+
+    @Override
+    protected void configureProps(ConnectionSettings settings) {
+        settings.setMockHttpClassname("com.splunk.cloudfwd.impl.sim.errorgen.cookies.UpdateableELBCookieEndpoints");
+        settings.setMaxTotalChannels(1);
+        settings.setMaxRetries(1);
+        settings.setAckTimeoutMS(10000);
+    }
+    
+    @Override
+    protected BasicCallbacks getCallbacks() {
+        return new BasicCallbacks(getNumEventsToSend()) {
+            @Override
+            protected boolean isExpectedFailureType(Exception e){
+                LOG.debug("isExpectedFailureType: e={}", e.toString());
+                return (e instanceof HecNonStickySessionException);
+            }
+            
+        };
+    }
+
+}


### PR DESCRIPTION
Session expiration handling and cookies set on first request only. Handle duplicated acknowledgement Ids to detect non-sticky behavior. 

These changes were tested sending data via ELB. Confirmed the following behavior:
1) when session expiration is set to some value, new channels not created
2) when session cookies are disabled, eventually event posts get duplicated ack IDs and eventually a channel get closed and replaced, events in flight get failed.
3) when session expiration is disabled, channels get created. 

TODO: need to add mocked tests validating the code change. 

* Set channel cookies on first request only
This change assumes that sticky session cookies can be set on in the first request to the backend. All subsequent requests should have either no cookie or match the cookie assigned to the channel. 
* Validates that max-age is not specified
* Handle Sticky Session Violation when duplicated ack IDs are detected. 